### PR TITLE
Fix accordion example spacing

### DIFF
--- a/docs/.vuepress/components/cdr-doc-example-code-pair.vue
+++ b/docs/.vuepress/components/cdr-doc-example-code-pair.vue
@@ -33,7 +33,7 @@
               label">
         {{ label || slotLabel }}
       </span>
-      <div class="cdr-doc-example-code-pair__item-example" :style="{ 'margin-top': `${exampleMarginTop}px` }">
+      <div class="cdr-doc-example-code-pair__item-example">
         <!-- Will be replaced with the compiled template code on mount -->
         <component :is="`cdr-doc-html-example-${slotLabel}-${instanceId}`" />
       </div>
@@ -108,10 +108,6 @@
       hideCode: {
         default: true,
         type: Boolean
-      },
-      exampleMarginTop: {
-        type: Number,
-        default: 0,
       },
       model: {
         type: Object,
@@ -221,6 +217,7 @@
     
     &__item-example {
       width: 100%;
+      margin-top: 15px; // prevents full-width components from displaying on top of light/dark toggle
     }
   }
 

--- a/docs/.vuepress/components/cdr-doc-example-code-pair.vue
+++ b/docs/.vuepress/components/cdr-doc-example-code-pair.vue
@@ -33,7 +33,7 @@
               label">
         {{ label || slotLabel }}
       </span>
-      <div class="cdr-doc-example-code-pair__item-example">
+      <div class="cdr-doc-example-code-pair__item-example" :style="{ 'margin-top': `${exampleMarginTop}px` }">
         <!-- Will be replaced with the compiled template code on mount -->
         <component :is="`cdr-doc-html-example-${slotLabel}-${instanceId}`" />
       </div>
@@ -108,6 +108,10 @@
       hideCode: {
         default: true,
         type: Boolean
+      },
+      exampleMarginTop: {
+        type: Number,
+        default: 0,
       },
       model: {
         type: Object,

--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -144,7 +144,7 @@
 
 Section borders expand to full width of container.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx" :example-margin-top="15">
+<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
 
 ```html
   <cdr-accordion>
@@ -182,7 +182,7 @@ Section borders expand to full width of container.
 
 Reduced spacing around title and content body. Also, smaller font sizes resulting in an overall denser display of content.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx" :example-margin-top="15">
+<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
 
 ```html
   <cdr-accordion :compact="true">

--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -144,7 +144,7 @@
 
 Section borders expand to full width of container.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
+<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx" :example-margin-top="15">
 
 ```html
   <cdr-accordion>
@@ -182,7 +182,7 @@ Section borders expand to full width of container.
 
 Reduced spacing around title and content body. Also, smaller font sizes resulting in an overall denser display of content.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
+<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx" :example-margin-top="15">
 
 ```html
   <cdr-accordion :compact="true">


### PR DESCRIPTION
I added a new prop (exampleMarginTop) to cdr-doc-example-code-pair so that spacing can be added between the component and the light/dark toggle. 