### PR TITLE
Update README.md

### DIFF
--- a/docs/components/image/README.md
+++ b/docs/components/image/README.md
@@ -371,7 +371,7 @@ To incorporate the required assets for a component, use the following steps:
 
 ### 1. Install using NPM
 
-Install the `CdrImg` package using `npm` in your terminal:
+Install the CdrImg package using `npm` in your terminal:
 
 _Terminal_
 


### PR DESCRIPTION
- In the Installation section, Install using NPM: CdrImg should not be code font style

- Also, in the Props (I don't know how to edit this section), for the crop prop, there is a correction for possible values (my error in the gDocs): { ‘left’ | ‘x-center’ | ‘right’ | ‘top’ | ‘y-center’ | ‘bottom’ }. Note the character change from "«" to "|"