### PR TITLE
Add IE 11 to browser support matrix

### DIFF
--- a/docs/about/browser-support/README.md
+++ b/docs/about/browser-support/README.md
@@ -19,9 +19,9 @@
 Cedar supports the latest, stable releases of the following browsers and platforms. Support is not guaranteed for platforms beyond this list, and any issues reported against unsupported platforms will be investigated at the team’s earliest opportunity.
 Officially supported platforms are:
 
-| **Platform** | **Chrome** | **Firefox** | **Safari**     | **Edge** |
-|:-------------|:-----------|:------------|:---------------|:---------|
-| Windows 10   | Yes        | Yes         |                | Yes      |
-| Windows 7    | Yes        |             |                |          |
-| Mobile iOS   |            |             | Mobile version |          |
-| OS X 10.13   | Yes        |             | Yes            |          |
+| **Platform** | **Chrome** | **Firefox** | **Safari**     | **Edge** |  **IE11** |
+|:-------------|:-----------|:------------|:---------------|:---------|:----------|
+| Windows 10   | Yes        | Yes         |                | Yes      |   Yes     |
+| Windows 7    | Yes        |             |                |          |           |
+| Mobile iOS   |            |             | Mobile version |          |           |
+| OS X 10.13   | Yes        |             | Yes            |          |           |


### PR DESCRIPTION
We now do AVR tests against IE 11 on Windows 10.  It is trivial to extend this to windows 7 if that is seen as needed.  All it costs is test execution time.