### PR TITLE
make component tabs stick to the top of the page

### DIFF
--- a/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
+++ b/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
@@ -51,6 +51,10 @@ export default {
       type: String,
       default: '48'
     },
+    tabPanelOffset: {
+      type: String,
+      default: '64'
+    },
     appendedItems: {
       type: Array,
       default: function() {
@@ -291,7 +295,7 @@ export default {
     },
     softScroll(id) {
       const anchoredSection = document.querySelector(id);
-      const scrollPosition = anchoredSection.offsetTop;
+      const scrollPosition = anchoredSection.offsetTop - this.tabPanelOffset;
 
       window.scroll({
         top: scrollPosition,

--- a/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
+++ b/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
@@ -313,6 +313,7 @@ export default {
   .cdr-doc-local-anchor-nav {
     overflow-y: auto;
     position: sticky;
+    padding-top: $cdr-space-inset-two-x;
   }
 
   .cdr-doc-local-anchor-nav__list {

--- a/docs/.vuepress/components/cdr-doc-tabs.vue
+++ b/docs/.vuepress/components/cdr-doc-tabs.vue
@@ -14,7 +14,7 @@
         </li>
       </ul>
     </div>
-    <div class="cdr-doc-tabs__panels">
+    <div class="cdr-doc-tabs__panels" ref="tabPanel">
       <div class="cdr-doc-tabs__panels-inner">
         <div v-for="tab in tabLabelData" class="cdr-doc-tab-panel" :class="{'cdr-doc-tab-panel--active': tab.active }" :aria-hidden="!tab.active" :aria-labelledby="tab.linkId">
           <slot :name="tab.label"/>
@@ -73,6 +73,7 @@ export default {
       if (event) event.preventDefault();
       this.activeTab = activeTabLabel;
       this.$root.$emit('cdrDocTabsActiveTabSwitched', this.activeTab);
+      this.$refs['tabPanel'].scrollIntoView(true);
     }
   }
 }
@@ -87,6 +88,11 @@ export default {
     padding: $cdr-space-inset-one-x;
     padding-bottom: 0;
     padding-top: 0;
+    background-color: $cdr-color-background-lightest;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    border-top: $cdr-doc-border-separator;
   }
 
   .cdr-doc-tabs-list {
@@ -101,7 +107,7 @@ export default {
   .cdr-doc-tabs__panels {
     padding: $cdr-space-inset-one-x;
     padding-bottom: 0;
-    padding-top: 0;
+    padding-top: $cdr-space-inset-two-x;
   }
 
   .cdr-doc-tabs__panels-inner {


### PR DESCRIPTION
I was poking around the docs site and noticed that on the components page the "nav"/"TOC" elements on the left and right hand side both are "sticky" but the tabs panel at the top of the components page is not. 

This was definitely something that tripped me up as a cedar consumer, as I would be looking for info about a component and forget that there are other tabs available. I made a quick PR just to show what this would be like, as a possibly iterative improvement we could make to the doc site while we figure out the larger questions around our docs.

![sticky_tabs](https://user-images.githubusercontent.com/48567940/57657393-1b94fc80-7590-11e9-9340-d2bdb0eb9441.gif)
