### PR TITLE
update repository-hrefs in code snippets to use single source of truth

### DIFF
--- a/docs/.vuepress/components/cdr-doc-code-snippet.vue
+++ b/docs/.vuepress/components/cdr-doc-code-snippet.vue
@@ -27,7 +27,7 @@
         </span>
       </div>
       <div class="cdr-doc-code-snippet__action-wrapper">
-        <a class="cdr-doc-code-snippet__action" :href="repositoryHref" target="_blank" rel="noopener noreferrer" v-if="repositoryHref">
+        <a class="cdr-doc-code-snippet__action" :href="repositoryRoot + repositoryHref" target="_blank" rel="noopener noreferrer" v-if="repositoryHref">
           <img class="cdr-doc-code-snippet__action-icon" :src="$withBase(`/GitHub@2x.png`)" alt="View source in repository"/>
         </a>
         <span class="cdr-doc-code-snippet__tooltip cdr-doc-code-snippet__tooltip--show-on-hover">
@@ -90,7 +90,8 @@ export default {
       copyError: false,
       copyNotSupported: false,
       codeHidden: false,
-      hideCodeToggleText: 'Hide code'
+      hideCodeToggleText: 'Hide code',
+      repositoryRoot: 'https://github.com/rei/rei-cedar/tree/19.02.1'
     }
   },
   created: function() {

--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -139,7 +139,7 @@
 
 Section borders expand to full width of container.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
+<cdr-doc-example-code-pair repository-href="/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
 
 ```html
   <cdr-accordion>
@@ -177,7 +177,7 @@ Section borders expand to full width of container.
 
 Reduced spacing around title and content body. Also, smaller font sizes resulting in an overall denser display of content.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
+<cdr-doc-example-code-pair repository-href="/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
 
 ```html
   <cdr-accordion :compact="true">
@@ -217,7 +217,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
 
 Border aligns to the title text and expand/collapse icon.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/accordion" sandbox-href="https://codesandbox.io/s/m9jm5rw1zx">
 
 ```html
   <cdr-accordion :border-aligned="true">

--- a/docs/components/block-quote/README.md
+++ b/docs/components/block-quote/README.md
@@ -148,7 +148,7 @@
 
 Default block quote can be used with the following HTML tags: `<p>`, `<div>`, `<aside>`. This is responsive with styles for XS breakpoint
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.2/src/components/quote" sandbox-href="https://codesandbox.io/s/q722z00mk4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/quote" sandbox-href="https://codesandbox.io/s/q722z00mk4">
 
 ```html
 <div>

--- a/docs/components/breadcrumb/README.md
+++ b/docs/components/breadcrumb/README.md
@@ -129,7 +129,7 @@
 
 Complete breadcrumb string with all items visible.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/breadcrumb" sandbox-href="https://codesandbox.io/s/mm9qpyjojp" :backgroundToggle="false" :codeMaxHeight= false >
+<cdr-doc-example-code-pair repository-href="/src/components/breadcrumb" sandbox-href="https://codesandbox.io/s/mm9qpyjojp" :backgroundToggle="false" :codeMaxHeight= false >
 
 ```html
   <cdr-breadcrumb
@@ -148,7 +148,7 @@ Complete breadcrumb string with all items visible.
 
 Long breadcrumb path shortened to display the last 2 items with hidden links indicated by ellipsis.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/breadcrumb" sandbox-href="https://codesandbox.io/s/mm9qpyjojp" :backgroundToggle="false" :codeMaxHeight= false>
+<cdr-doc-example-code-pair repository-href="/src/components/breadcrumb" sandbox-href="https://codesandbox.io/s/mm9qpyjojp" :backgroundToggle="false" :codeMaxHeight= false>
 
 ```html
     <cdr-breadcrumb

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -207,7 +207,7 @@
 
 Use primary buttons for actions to complete a task or move forward in a process such as &quot;Add to cart.&quot; There is only 1 primary action per major page section.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
+<cdr-doc-example-code-pair repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
 
 ```html
   <cdr-button>Add to cart</cdr-button>
@@ -222,7 +222,7 @@ Use primary buttons for actions to complete a task or move forward in a process 
 
 Use secondary buttons for all actions that do not move the user to the next step or are additional user actions such as &quot;Add to wish list&quot; or &quot;Find a campout near you.&quot;
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
+<cdr-doc-example-code-pair repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
 
 ```html
   <cdr-button modifier="secondary">Add to wish list</cdr-button>
@@ -235,7 +235,7 @@ Use secondary buttons for all actions that do not move the user to the next step
 
 Pair an icon with text to improve recognition about an object or action.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
+<cdr-doc-example-code-pair repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
 
 ```html
   <div>
@@ -272,7 +272,7 @@ Pair an icon with text to improve recognition about an object or action.
 
 Use to visually communicate an object or action in limited space. Include alternative text to describe what button does.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
 
 ```html
   <div>
@@ -297,7 +297,7 @@ Use to visually communicate an object or action in limited space. Include altern
 
 Change the button size based on where button is used. Default size is medium. Small is used for supplemental user actions such as product comparison or filter. Large is used for &quot;Add to cart&quot; on product pages or Call to Action.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/wk2o3k9qwk" >
 
 ```html
     <div>

--- a/docs/components/caption/README.md
+++ b/docs/components/caption/README.md
@@ -114,7 +114,7 @@
 
 Caption aligns to the left alongside the body copy with inset padding. Default caption includes summary and credit.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.2/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l" >
 
 ```html
   <cdr-caption 
@@ -128,7 +128,7 @@ Caption aligns to the left alongside the body copy with inset padding. Default c
 
 Summary has same CSS styles as the default; however, only the summary element is displayed.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.2/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l">
 
 ```html
   <cdr-caption 
@@ -142,7 +142,7 @@ Summary has same CSS styles as the default; however, only the summary element is
 
 Credit has same CSS styles as the default; however, only the credit element is displayed.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.2/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l">
 
 ```html
   <cdr-caption 
@@ -156,7 +156,7 @@ Credit has same CSS styles as the default; however, only the credit element is d
 
 The captions component is text-only; however, it is meant to be displayed in the context of a media object.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.2/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" sandbox-href="https://codesandbox.io/s/889z57925l" >
 
 ```html
 <figure>

--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -197,7 +197,7 @@
 
 Default and standard spacing for checkboxes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" :model="{ex1: true, ex2: false, ex3: false}" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" :model="{ex1: true, ex2: false, ex3: false}" >
 
 ```html
 <div>
@@ -213,7 +213,7 @@ Default and standard spacing for checkboxes.
 
 Compact spacing for checkboxes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" :model="{ex1: true, ex2: false, ex3: false}">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" :model="{ex1: true, ex2: false, ex3: false}">
 
 ```html
 <div>
@@ -229,7 +229,7 @@ Compact spacing for checkboxes.
 
 Displays status for checkbox group by indicating that some of the sub-selections in a list are selected. Provides user with ability to select or unselect all items in the list’s sub-group.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" :model="{ex1: false}">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" :model="{ex1: false}">
 
 ```html
 <div>
@@ -243,7 +243,7 @@ Displays status for checkbox group by indicating that some of the sub-selections
 
 Custom styles for checkboxes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" class="custom-checkbox-example" :model="{ex1: true, ex2: false, ex3: false}">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" sandbox-href="https://codesandbox.io/s/z30opplw43" class="custom-checkbox-example" :model="{ex1: true, ex2: false, ex3: false}">
 
 ```html
 <div>

--- a/docs/components/cta/README.md
+++ b/docs/components/cta/README.md
@@ -157,7 +157,7 @@
 
 Use dark Call to Action over a light background image or color to provide proper contrast. This is the default Call to Action style.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
 
 ```html
   <cdr-cta 
@@ -174,7 +174,7 @@ Use dark Call to Action over a light background image or color to provide proper
 
 Use light Call to Action over a dark background image or color to provide proper contrast.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
+<cdr-doc-example-code-pair repository-href="/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
 
 ```html
   <cdr-cta 
@@ -191,7 +191,7 @@ Use light Call to Action over a dark background image or color to provide proper
 
 Use sale Call to Action for off-price placements.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
+<cdr-doc-example-code-pair repository-href="/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
 
 ```html
   <cdr-cta 
@@ -208,7 +208,7 @@ Use sale Call to Action for off-price placements.
 
 Use brand Call to Action as an alternative.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
+<cdr-doc-example-code-pair repository-href="/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
 
 ```html
   <cdr-cta
@@ -225,7 +225,7 @@ Use brand Call to Action as an alternative.
 
 Adds drop shadow to increase contrast and visibility of Call to Action when placed over an image.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
+<cdr-doc-example-code-pair repository-href="/src/components/cta" sandbox-href="https://codesandbox.io/s/9ojj43x1op">
 
 ```html
   <cdr-cta 

--- a/docs/components/data-tables/README.md
+++ b/docs/components/data-tables/README.md
@@ -229,7 +229,7 @@
 
 Basic layout with a column of row headers.  Rows alternate background colors.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/rj8l4k58p4" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/rj8l4k58p4" >
 
 ```html
   <cdr-data-table
@@ -246,7 +246,7 @@ Basic layout with a column of row headers.  Rows alternate background colors.
 
 Layout for making comparisons such as between size/sleeve length. Column headers and row headers are displayed. When columns scroll, row header column is locked in place.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/rj8l4k58p4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/rj8l4k58p4">
 
 ```html
   <cdr-data-table
@@ -264,7 +264,7 @@ Layout for making comparisons such as between size/sleeve length. Column headers
 
 Layout with reduced spacing within each cell. All cells are borderless. Defines a column of row headers. 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button" sandbox-href="https://codesandbox.io/s/rj8l4k58p4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" sandbox-href="https://codesandbox.io/s/rj8l4k58p4">
 
 ```html
   <cdr-data-table modifier="compact borderless" id="manual-example">

--- a/docs/components/grid/README.md
+++ b/docs/components/grid/README.md
@@ -170,7 +170,7 @@
 
 Use rows and columns to lay out content by specifying equal-widths for all columns
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/18r9z588l" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/18r9z588l" >
 
 ```html
 <div class="grid-example-wrap">
@@ -223,7 +223,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Left
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
 
 ```html
 <div class="grid-example-wrap">
@@ -245,7 +245,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Center
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
 
 ```html
 <div class="grid-example-wrap">
@@ -267,7 +267,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Right
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
 
 ```html
 <div class="grid-example-wrap">
@@ -289,7 +289,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Around
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
 
 ```html
 <div class="grid-example-wrap">
@@ -311,7 +311,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Between
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/9z3nqnp2lw" >
 
 ```html
 <div class="grid-example-wrap">
@@ -337,7 +337,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Top
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
 
 ```html
 <div class="grid-example-wrap">
@@ -359,7 +359,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Bottom
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
 
 ```html
 <div class="grid-example-wrap">
@@ -381,7 +381,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Middle
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
 
 ```html
 <div class="grid-example-wrap">
@@ -403,7 +403,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Stretch
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/18j2kwqy8j" >
 
 ```html
 <div class="grid-example-wrap">
@@ -429,7 +429,7 @@ Defines gutter size for all columns on a row and maintains gutter size by breakp
 
 ### Default
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/l72jz831mq" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/l72jz831mq" >
 
 ```html
 <div class="grid-example-wrap">
@@ -460,7 +460,7 @@ Defines gutter size for all columns on a row and maintains gutter size by breakp
 
 ### xxs
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/l72jz831mq" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/l72jz831mq" >
 
 ```html
 <div class="grid-example-wrap">
@@ -491,7 +491,7 @@ Defines gutter size for all columns on a row and maintains gutter size by breakp
 
 ### None
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/l72jz831mq" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/l72jz831mq" >
 
 ```html
 <div class="grid-example-wrap">
@@ -526,7 +526,7 @@ Defines direction for items in a container for all columns of a row. This applie
 
 ### Default
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/nn29799pyj" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/nn29799pyj" >
 
 ```html
 <div class="grid-example-wrap">
@@ -557,7 +557,7 @@ Defines direction for items in a container for all columns of a row. This applie
 
 ### Vertical
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/nn29799pyj" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/nn29799pyj" >
 
 ```html
 <div class="grid-example-wrap">
@@ -592,7 +592,7 @@ Wrapping columns is the default; however, it is possible to disable or enable co
 
 ### Wrap (Default)
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/r48j2yw7kq" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/r48j2yw7kq" >
 
 ```html
 <div class="grid-example-wrap">
@@ -620,7 +620,7 @@ Wrapping columns is the default; however, it is possible to disable or enable co
 
 ### Nowrap (Scroll)
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/r48j2yw7kq" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/r48j2yw7kq" >
 
 ```html
 <div class="grid-example-wrap">
@@ -652,7 +652,7 @@ Controls column width by overriding columns value for a specific column or colum
 
 ### 12 Cols
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -701,7 +701,7 @@ Controls column width by overriding columns value for a specific column or colum
 
 ### Span 2
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -747,7 +747,7 @@ Controls column width by overriding columns value for a specific column or colum
 
 ### Span 4
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -791,7 +791,7 @@ Adds empty space (or columns) to left or right of a column, either to the left (
 
 ### Offset Left
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -822,7 +822,7 @@ Adds empty space (or columns) to left or right of a column, either to the left (
 
 ### Offset Right
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -855,7 +855,7 @@ Adds empty space (or columns) to left or right of a column, either to the left (
 
 Overrides row-level alignment for a column. This can be applied to an individual column.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -887,7 +887,7 @@ Defines nested columns (also known as `isRow`).
 
 ### Simple
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/x931y6r7q" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/x931y6r7q" >
 
 ```html
 <div class="grid-example-wrap">
@@ -914,7 +914,7 @@ Defines nested columns (also known as `isRow`).
 
 ### Complex
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid" sandbox-href="https://codesandbox.io/s/x931y6r7q" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" sandbox-href="https://codesandbox.io/s/x931y6r7q" >
 
 ```html
 <div class="grid-example-wrap">

--- a/docs/components/headings/README.md
+++ b/docs/components/headings/README.md
@@ -76,7 +76,7 @@
 
 Use for responsive display heading.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4" >
 
 ```html
   <cdr-text
@@ -92,7 +92,7 @@ Use for responsive display heading.
 
 Use for non-responsive display heading that maintains font size across all viewport sizes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="display-static">
@@ -106,7 +106,7 @@ Use for non-responsive display heading that maintains font size across all viewp
 
 Use for a responsive large heading.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="heading-large">
@@ -120,7 +120,7 @@ Use for a responsive large heading.
 
 Use for non-responsive large heading that maintains font size across all viewport sizes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="heading-large-static">
@@ -134,7 +134,7 @@ Use for non-responsive large heading that maintains font size across all viewpor
 
 Use for a responsive medium heading.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="heading-medium">
@@ -148,7 +148,7 @@ Use for a responsive medium heading.
 
 Use for non-responsive medium heading that maintains font size across all viewport sizes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="heading-medium-static">
@@ -162,7 +162,7 @@ Use for non-responsive medium heading that maintains font size across all viewpo
 
 Use for a responsive small heading.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="heading-small">
@@ -176,7 +176,7 @@ Use for a responsive small heading.
 
 Use for non-responsive small heading that maintains font size across all viewport sizes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="heading-small-static">
@@ -190,7 +190,7 @@ Use for non-responsive small heading that maintains font size across all viewpor
 
 Use for subheadings that are positioned beneath small headings.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <cdr-text modifier="subheading">

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -134,7 +134,7 @@
 
 A collection of SVG icon files composed into a single file. This method provides a single server download request and caches icons for display. This is the most efficient way of displaying large numbers of icons.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.1/src/components/icon" sandbox-href="https://codesandbox.io/s/wq7x673mol" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/icon" sandbox-href="https://codesandbox.io/s/wq7x673mol" >
 
 ```html
   <cdr-icon-sprite />
@@ -149,7 +149,7 @@ A collection of SVG icon files composed into a single file. This method provides
 
 Display any icon separately. This may be the easiest way to use an icon on a page however it is not recommended for every circumstance. When using a large number of icons, it will generate multiple server requests and slow down performance.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.1/src/components/icon" sandbox-href="https://codesandbox.io/s/wq7x673mol" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/icon" sandbox-href="https://codesandbox.io/s/wq7x673mol" >
 
 ```html
   <icon-caret-up />
@@ -162,7 +162,7 @@ Display any icon separately. This may be the easiest way to use an icon on a pag
 
 Create a new SVG icon using any valid internal SVG markup. This method creates an outer SVG wrapper for accessibility and styles. This is not recommended if using a large number of icons.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.1/src/components/icon" sandbox-href="https://codesandbox.io/s/wq7x673mol" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/icon" sandbox-href="https://codesandbox.io/s/wq7x673mol" >
 
 ```html
   <cdr-icon>

--- a/docs/components/image/README.md
+++ b/docs/components/image/README.md
@@ -116,7 +116,7 @@
 
 Use for images with no responsive qualities.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
 
 ```html
 
@@ -132,7 +132,7 @@ Use for images with no responsive qualities.
 
 Apply rules to an image using ratio and crop properties. The below example is cropped using top alignment with the aspect ratio set as 9-16
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
 
 ```html
 <cdr-img
@@ -148,7 +148,7 @@ Apply rules to an image using ratio and crop properties. The below example is cr
 
 Use the cover property to resize the background image to fill the entire container.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
 
 ```html
 <cdr-img
@@ -170,7 +170,7 @@ Apply a radius to an image.
 ### Rounded
 The below example is cropped using center alignment with the aspect ratio set as square and the radius set as rounded.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
 
 ```html
   <cdr-img
@@ -187,7 +187,7 @@ The below example is cropped using center alignment with the aspect ratio set as
 ### Circle
 The below example is cropped using center alignment with the aspect ratio set as square and the radius set as circle.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" sandbox-href="https://codesandbox.io/s/wwnr4jzwr7" >
 
 ```html
   <cdr-img

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -213,7 +213,7 @@
 ## Default
 Basic input field with label.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -236,7 +236,7 @@ Basic input field with label.
 
 Basic input field with label and required tag.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -253,7 +253,7 @@ Basic input field with label and required tag.
 
 Change size for the input field. Default size is medium.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -276,7 +276,7 @@ Change size for the input field. Default size is medium.
 
 Input field with no label.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -293,7 +293,7 @@ Input field with no label.
 
 Multiple line input field with expander control in lower right.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -310,7 +310,7 @@ Multiple line input field with expander control in lower right.
 
 Input field with link text on right.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -330,7 +330,7 @@ Input field with link text on right.
 
 Input field with icon above input field on right.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-icon-sprite />
@@ -354,7 +354,7 @@ Input field with icon above input field on right.
 
 Input field with helper or hint text below input field.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -374,7 +374,7 @@ Input field with helper or hint text below input field.
 
 Input field with icon inserted into input field on left. Icon is decorative and not intended for any action.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
 ```html
 <cdr-icon-sprite />
@@ -398,7 +398,7 @@ Input field with icon inserted into input field on left. Icon is decorative and 
 
 Input field with icon inserted into input field on right. Icon is decorative and not intended for any action.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.12.2/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" sandbox-href="https://codesandbox.io/s/7wkl26oyoj" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
 ```html
 <cdr-icon-sprite />

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -110,7 +110,7 @@
 
 Display within body copy for articles, hub cards, footer, or recommendations.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9" >
 
 ```html
 <cdr-text>
@@ -132,7 +132,7 @@ Display within body copy for articles, hub cards, footer, or recommendations.
 
 Display independently with a call to action. Some examples are for finding a store, or viewing related products.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9">
+<cdr-doc-example-code-pair repository-href="/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9">
 
 ```html
   <cdr-link href="https://www.rei.com" modifier="standalone">
@@ -146,7 +146,7 @@ Display independently with a call to action. Some examples are for finding a sto
 
 Display standalone link with icon on left.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9">
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9">
 
 ```html
   <div>
@@ -169,7 +169,7 @@ Display standalone link with icon on left.
 
 Display standalone link with icon on right.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9">
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" sandbox-href="https://codesandbox.io/s/jnv1rko1z9">
 
 ```html
   <div>

--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -93,7 +93,7 @@
 
 Collect items to be displayed in a list when items are not marked with bullets.  This is the default and is also known as unordered and undecorated “bare” list.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" :codeMaxHeight= false >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" :codeMaxHeight= false >
 <template slot="Default">
 
 ```html
@@ -131,7 +131,7 @@ Collect items to be displayed in a list when items are not marked with bullets. 
 
 Collect related items that don’t need to be in a specific order or sequence. List items are typically marked with bullets.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
 <template slot="Default">
 
 ```html
@@ -170,7 +170,7 @@ Collect related items that don’t need to be in a specific order or sequence. L
 
 Collect related items with numeric order or sequence. Numbering starts at 1 with the first list item and increases by increments of 1 for each successive ordered list item.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
 <template slot="Default">
 
 ```html
@@ -208,7 +208,7 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
 
 Display items horizontally with no divider.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
 <template slot="Default">
 
 ```html
@@ -238,7 +238,7 @@ Display items horizontally with no divider.
 
 Display items horizontally, separated by a bullet character.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="https://github.com/rei/rei-cedar/tree/18.07.2/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
+<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" sandbox-href="https://codesandbox.io/s/1q95wpz4rq" >
 <template slot="Default">
 
 ```html

--- a/docs/components/paragraphs/README.md
+++ b/docs/components/paragraphs/README.md
@@ -100,7 +100,7 @@
 
 Used as default font style for all text information. Also known as body-default in UI ToolKit.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4" >
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4" >
 
 ```html
   <cdr-text>Pack everything you need with this handy checklist! We include the 10 essentials and more for comfort in the backcountry.</cdr-text>
@@ -112,7 +112,7 @@ Used as default font style for all text information. Also known as body-default 
 
 Used for editorial content such as long-form articles like Expert Advice pages or editorial content on PDP pages.  Also known as body-editorial in UI ToolKit.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.07.1/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" sandbox-href="https://codesandbox.io/s/10lx8v0qm4">
 
 ```html
   <div>

--- a/docs/components/pull-quote/README.md
+++ b/docs/components/pull-quote/README.md
@@ -146,7 +146,7 @@
 
 Default pull quote can be used with the following HTML tags: `<p>`, `<div>`, `<aside>`. For XS breakpoint, a border is below pull quote and font size is smaller.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.09.2/src/components/quote" sandbox-href="https://codesandbox.io/s/q722z00mk4">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/quote" sandbox-href="https://codesandbox.io/s/q722z00mk4">
 
 ```html
 <div>

--- a/docs/components/radio/README.md
+++ b/docs/components/radio/README.md
@@ -134,7 +134,7 @@
 ## Default
 Default and standard spacing for radio buttons.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/radio" sandbox-href="https://codesandbox.io/s/4rx86n66l9" :backgroundToggle="false" :codeMaxHeight="false" :model="{ex: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/radio" sandbox-href="https://codesandbox.io/s/4rx86n66l9" :backgroundToggle="false" :codeMaxHeight="false" :model="{ex: ''}">
 
 ```html
 <div>
@@ -164,7 +164,7 @@ Default and standard spacing for radio buttons.
 
 Compact spacing for radio buttons.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/radio" sandbox-href="https://codesandbox.io/s/4rx86n66l9" :backgroundToggle="false" :codeMaxHeight="false" :model="{ex: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/radio" sandbox-href="https://codesandbox.io/s/4rx86n66l9" :backgroundToggle="false" :codeMaxHeight="false" :model="{ex: ''}">
 
 ```html
 <div>
@@ -197,7 +197,7 @@ Compact spacing for radio buttons.
 
 Custom styles for radio buttons.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.08.1/src/components/radio" sandbox-href="https://codesandbox.io/s/4rx86n66l9" :backgroundToggle="false" :codeMaxHeight="false" class="custom-radio-example" :model="{ex: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/radio" sandbox-href="https://codesandbox.io/s/4rx86n66l9" :backgroundToggle="false" :codeMaxHeight="false" class="custom-radio-example" :model="{ex: ''}">
 
 ```html
 <div>

--- a/docs/components/rating/README.md
+++ b/docs/components/rating/README.md
@@ -121,7 +121,7 @@
 
 Shows review rating with up to 5 stars highlighted. If rating is zero, star icons are displayed using the grey outline star icon. 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.11.1/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
 
 ```html
 <div>
@@ -136,7 +136,7 @@ Shows review rating with up to 5 stars highlighted. If rating is zero, star icon
 
 Creates a link to the corresponding review content if on the same page.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.11.1/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
 
 ```html
 <div>
@@ -155,7 +155,7 @@ Creates a link to the corresponding review content if on the same page.
 
 Removes the word "Reviews" from the label for limited space layout.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.11.1/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
 
 ```html
 <div>
@@ -170,7 +170,7 @@ Removes the word "Reviews" from the label for limited space layout.
 
 Change size for the star icon and text. Default size is medium.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="https://github.com/rei/rei-cedar/tree/18.11.1/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
+<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" sandbox-href="https://codesandbox.io/s/30r682534m">
 
 ```html
 <div>

--- a/docs/components/tabs/README.md
+++ b/docs/components/tabs/README.md
@@ -149,7 +149,7 @@ Tab buttons align left and bottom border expands to full width of container.
 
 Reduced spacing around the tab buttons create a denser visual design.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.11.1/src/components/tabs" sandbox-href="https://codesandbox.io/s/6w37mxwozn" :backgroundToggle="false" :codeMaxHeight="false">
+<cdr-doc-example-code-pair repository-href="/src/components/tabs" sandbox-href="https://codesandbox.io/s/6w37mxwozn" :backgroundToggle="false" :codeMaxHeight="false">
 
 ```html
 <cdr-tabs modifier="compact" height="100px">
@@ -166,7 +166,7 @@ Reduced spacing around the tab buttons create a denser visual design.
 
 Tab buttons space evenly across the container.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.11.1/src/components/tabs" sandbox-href="https://codesandbox.io/s/6w37mxwozn" :backgroundToggle="false" :codeMaxHeight="false" class="custom-radio-example">
+<cdr-doc-example-code-pair repository-href="/src/components/tabs" sandbox-href="https://codesandbox.io/s/6w37mxwozn" :backgroundToggle="false" :codeMaxHeight="false" class="custom-radio-example">
 
 ```html
 <cdr-tabs modifier="full-width" height="100px">
@@ -183,7 +183,7 @@ Tab buttons space evenly across the container.
 
 Bottom border of tab header list is removed.
 
-<cdr-doc-example-code-pair repository-href="https://github.com/rei/rei-cedar/tree/18.11.1/src/components/tabs" sandbox-href="https://codesandbox.io/s/6w37mxwozn" :backgroundToggle="false" :codeMaxHeight="false" class="custom-radio-example">
+<cdr-doc-example-code-pair repository-href="/src/components/tabs" sandbox-href="https://codesandbox.io/s/6w37mxwozn" :backgroundToggle="false" :codeMaxHeight="false" class="custom-radio-example">
 
 ```html
 <cdr-tabs modifier="no-border" height="100px">


### PR DESCRIPTION
noticed that all of the "repository-href' links for our code examples are pointing to the wrong cedar version. updated the logic to construct that URL automatically.