### PR TITLE
utility class/line-height fix

### DIFF
--- a/docs/.vuepress/components/IconGrid.vue
+++ b/docs/.vuepress/components/IconGrid.vue
@@ -1,7 +1,7 @@
 <template>
   <cdr-row
       cols="3 6@md 10@lg"
-      class="cdr-stack--lg icon-demo-grid"
+      class="cdr-mb-space-two-x icon-demo-grid"
       gutter="xxs"
     >
       <cdr-col

--- a/docs/.vuepress/theme/Home.vue
+++ b/docs/.vuepress/theme/Home.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="home">
-    <div class="hero cdr-stack--xl">
+    <div class="hero cdr-mb-space-four-x">
       <cdr-img
         v-if="data.heroImage"
         class="hero__image"
@@ -13,7 +13,7 @@
         <cdr-text
           tag="h1"
           modifier="display"
-          class="cdr-stack"
+          class="cdr-mb-space-one-x"
         >{{ data.heroTitle }}</cdr-text>
         <p class="hero__description">{{ data.heroDescription }}</p>
       </div>
@@ -21,7 +21,7 @@
 
 
     <div class="cdr-container">
-      <cdr-row cols="1 2@md" align="middle" class="cdr-stack--xl">
+      <cdr-row cols="1 2@md" align="middle" class="cdr-mb-space-four-x">
         <cdr-col>
           <cdr-img
             class="getting-started-image"
@@ -53,9 +53,9 @@
         </cdr-col>
       </cdr-row>
 
-      <div class="home-hr cdr-stack--xl" role="presentation"></div>
+      <div class="home-hr cdr-mb-space-four-x" role="presentation"></div>
 
-      <cdr-row cols="1 2@md" class="cdr-stack--xl">
+      <cdr-row cols="1 2@md" class="cdr-mb-space-four-x">
         <cdr-col>
           <div class="cdr-text-center">
             <cdr-img
@@ -66,7 +66,7 @@
               cover
             />
             <h2 class="home-heading">Foundation</h2>
-            <cdr-text class="cdr-stack">Build cohesive digital experiences with the basic design elements that comprise the Cedar visual language.</cdr-text>
+            <cdr-text class="cdr-mb-space-one-x">Build cohesive digital experiences with the basic design elements that comprise the Cedar visual language.</cdr-text>
             <cdr-link
               :href="$withBase('/foundation/color/')"
               modifier="standalone"
@@ -83,7 +83,7 @@
               cover
             />
             <h2 class="home-heading">Components</h2>
-            <cdr-text class="cdr-stack">Use components as building blocks to create new digital products - usage, visual guidelines, and code included.</cdr-text>
+            <cdr-text class="cdr-mb-space-one-x">Use components as building blocks to create new digital products - usage, visual guidelines, and code included.</cdr-text>
             <cdr-link
               :href="$withBase('/components/buttons/')"
               modifier="standalone"
@@ -92,7 +92,7 @@
         </cdr-col>
       </cdr-row>
 
-      <div class="home-hr-tree cdr-stack--xl">
+      <div class="home-hr-tree cdr-mb-space-four-x">
         <cdr-img
           class="home-hr-tree__image"
           :src="$withBase('home/hr_tree.png')"
@@ -100,18 +100,18 @@
       </div>
 
 
-      <h2 class="home-heading cdr-text-center cdr-stack--xl">Resources</h2>
+      <h2 class="home-heading cdr-text-center cdr-mb-space-four-x">Resources</h2>
 
-      <cdr-row cols="1 2@md" class="cdr-stack--xl">
+      <cdr-row cols="1 2@md" class="cdr-mb-space-four-x">
         <cdr-col>
-          <div class="home-card cdr-inset">
+          <div class="home-card cdr-space-inset-one-x">
             <cdr-row align="middle">
               <cdr-col span="9">
                 <div>
                   <cdr-text
                     tag="h3"
                     modifier="heading-small-static"
-                    class="cdr-stack"
+                    class="cdr-mb-space-one-x"
                   >Cedar Sketch UI toolkit</cdr-text>
                   <cdr-link :href="$withBase('/getting-started/as-a-designer/')" modifier="standalone">Download the Sketch library</cdr-link>
                 </div>
@@ -125,14 +125,14 @@
           </div>
         </cdr-col>
         <cdr-col>
-          <div class="home-card cdr-inset">
+          <div class="home-card cdr-space-inset-one-x">
             <cdr-row align="middle">
               <cdr-col span="9">
                 <div>
                   <cdr-text
                     tag="h3"
                     modifier="heading-small-static"
-                    class="cdr-stack"
+                    class="cdr-mb-space-one-x"
                   >Vue.js components</cdr-text>
                   <cdr-link href="https://www.npmjs.com/org/rei" target="_blank" modifier="standalone">View the NPM repository</cdr-link>
                 </div>
@@ -146,24 +146,24 @@
           </div>
         </cdr-col>
         <cdr-col>
-          <div class="home-card cdr-inset">
+          <div class="home-card cdr-space-inset-one-x">
             <cdr-text
               tag="h3"
               modifier="heading-small-static"
-              class="cdr-stack"
+              class="cdr-mb-space-one-x"
             >Contribute to Cedar</cdr-text>
-            <cdr-text class="cdr-stack">The Cedar team welcomes contributions from the community. Learn how to become a pilot contributor.  </cdr-text>
+            <cdr-text class="cdr-mb-space-one-x">The Cedar team welcomes contributions from the community. Learn how to become a pilot contributor.  </cdr-text>
             <cdr-link :href="$withBase('/getting-started/as-an-adopter/?active-link=contributions')" modifier="standalone">Help build Cedar</cdr-link>
           </div>
         </cdr-col>
         <cdr-col>
-          <div class="home-card cdr-inset">
+          <div class="home-card cdr-space-inset-one-x">
             <cdr-text
               tag="h3"
               modifier="heading-small-static"
-              class="cdr-stack"
+              class="cdr-mb-space-one-x"
             >Feedback & support</cdr-text>
-            <cdr-text class="cdr-stack">Questions, ideas, or comments? Your feedback can help improve Cedar. </cdr-text>
+            <cdr-text class="cdr-mb-space-one-x">Questions, ideas, or comments? Your feedback can help improve Cedar. </cdr-text>
             <cdr-link href="mailto:cedar@rei.com" modifier="standalone">Get in touch</cdr-link>
           </div>
         </cdr-col>
@@ -311,6 +311,7 @@ export default {
   background-color: $cdr-color-background-lightest;
   border: 1px solid $partly-cloudy;
   border-radius: $cdr-radius-softer;
+  display: block;
 }
 
 .home-resource-icon {

--- a/docs/.vuepress/theme/styles/options.scss
+++ b/docs/.vuepress/theme/styles/options.scss
@@ -377,22 +377,3 @@ $ice-age: #ecf2f7;
 // $background-color-dark: #292929;
 // $suede-shoes: #5197cd;
 // $snap-decision: #e86868;
-
-
-// LEGACY UTILTIY CLASSES // 
-// !important is necessary to override
-
-.cdr-stack {
-  margin-bottom: 1.6rem !important;
-}
-.cdr-stack--lg {
-  margin-bottom: 3.2rem !important;
-}
-.cdr-stack--xl {
-  margin-bottom: 6.4rem !important;
-}
-
-.cdr-inset {
-  padding: 1.6rem !important;
-  display: block !important;
-}

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -261,15 +261,15 @@ List of icons with names and descriptions about when or how to use each icon. Ic
 ## Behavior
 When using icons with links or buttons, make sure that the icon communicates intended meaning.
 
-<do-dont :examples="$page.frontmatter.meaning" class="cdr-stack--lg"/>
+<do-dont :examples="$page.frontmatter.meaning" class="cdr-mb-space-two-x"/>
 
 Ensure that icons are sized to provide a minimum click or touch target.
 
-<do-dont :examples="$page.frontmatter.clearance" class="cdr-stack--lg"/>
+<do-dont :examples="$page.frontmatter.clearance" class="cdr-mb-space-two-x"/>
 
 Ensure that icons use contrast ratio of 4.5:1 between icon color and background color.
 
-<do-dont :examples="$page.frontmatter.color" class="cdr-stack--lg"/>
+<do-dont :examples="$page.frontmatter.color" class="cdr-mb-space-two-x"/>
 
 
 </cdr-doc-table-of-contents-shell>

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -159,7 +159,7 @@ Display standalone link with icon on left.
       <cdr-icon
           use="#shipping"
           inherit-color
-          class="cdr-inline-left--sm"
+          class="cdr-mr-space-half-x"
       />
       This item ships for FREE!
     </cdr-link>
@@ -183,7 +183,7 @@ Display standalone link with icon on right.
         <cdr-icon
             use="#external-link"
             inherit-color
-            class="cdr-inline-right--sm"/>
+            class="cdr-ml-space-half-x"/>
       </cdr-link>
   </div>
 ```

--- a/docs/components/rating/README.md
+++ b/docs/components/rating/README.md
@@ -128,7 +128,7 @@ Shows review rating with up to 5 stars highlighted. If rating is zero, star icon
 
 ```html
 <div>
-  <cdr-rating rating="3.33333" count="100" class="cdr-stack" />
+  <cdr-rating rating="3.33333" count="100" class="cdr-mb-space-one-x" />
   <cdr-rating rating="0" count="0" />
 </div>
 ```
@@ -162,7 +162,7 @@ Removes the word "Reviews" from the label for limited space layout.
 
 ```html
 <div>
-  <cdr-rating rating="3.33333" count="100" compact class="cdr-stack" />
+  <cdr-rating rating="3.33333" count="100" compact class="cdr-mb-space-one-x" />
   <cdr-rating rating="0" count="0" compact />
 </div>
 ```
@@ -177,12 +177,12 @@ Change size for the star icon and text. Default size is medium.
 
 ```html
 <div>
-  <cdr-rating size="small" rating="3.33333" count="100" compact class="cdr-stack" />
-  <cdr-rating size="medium" rating="3.33333" count="100" compact class="cdr-stack" />
-  <cdr-rating size="large" rating="3.33333" count="100" compact class="cdr-stack" />
-  <cdr-rating size="small" rating="0" count="0" compact class="cdr-stack" />
-  <cdr-rating size="medium" rating="0" count="0" compact class="cdr-stack" />
-  <cdr-rating size="large" rating="0" count="0" compact class="cdr-stack" />
+  <cdr-rating size="small" rating="3.33333" count="100" compact class="cdr-mb-space-one-x" />
+  <cdr-rating size="medium" rating="3.33333" count="100" compact class="cdr-mb-space-one-x" />
+  <cdr-rating size="large" rating="3.33333" count="100" compact class="cdr-mb-space-one-x" />
+  <cdr-rating size="small" rating="0" count="0" compact class="cdr-mb-space-one-x" />
+  <cdr-rating size="medium" rating="0" count="0" compact class="cdr-mb-space-one-x" />
+  <cdr-rating size="large" rating="0" count="0" compact class="cdr-mb-space-one-x" />
 </div>
 ```
 

--- a/docs/proving-grounds/code-snippet/README.md
+++ b/docs/proving-grounds/code-snippet/README.md
@@ -110,7 +110,7 @@ pageClass: cdr-doc-proving-ground
     <cdr-icon
       use="#mail"
       inherit-color
-      class="cdr-inline-left--sm"/>
+      class="cdr-mr-space-half-x"/>
     Icon on the left
   </cdr-link>
   ```

--- a/docs/proving-grounds/html-example-list/README.md
+++ b/docs/proving-grounds/html-example-list/README.md
@@ -32,7 +32,7 @@ pageClass: cdr-doc-proving-ground
 ```html
   <cdr-list
     modifier="unordered"
-    class="cdr-stack--lg"
+    class="cdr-mb-space-two-x"
   >
     <li>List item text</li>
     <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmodList ordered

--- a/package-lock.json
+++ b/package-lock.json
@@ -956,9 +956,9 @@
       "dev": true
     },
     "@rei/cedar": {
-      "version": "1.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-1.0.0-alpha.5.tgz",
-      "integrity": "sha512-ths6xoRZZA22kp2CJ3qCjAqM0JkiycsVCa4V9/C5H/xQ3IOOnUBJ29HtvrnXYOXTO1eZJzqFRoCWwjUPfzz0HQ=="
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-e+3iv5B3+CKOtzahCGeIGn+5UrEEG861Yu1bV3sK748yBeqaxJ1bgOeX5fPRKm7/nKiEYJUowsY4ZoM7j1Cf+w=="
     },
     "@shellscape/koa-send": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vuepress": "^0.14.10"
   },
   "dependencies": {
-    "@rei/cedar": "1.0.0-alpha.5",
+    "@rei/cedar": "1.0.0-alpha.6",
     "npm": "^6.9.0",
     "scrollmonitor": "^1.2.4",
     "smoothscroll-polyfill": "^0.4.3",


### PR DESCRIPTION
- pulls in cedar alpha.6 which fixes line-height issue, makes util classes usable with cdr-text
- updates all the old utility classes in this project to use the new ones

There are some subtle differences between this branch and master due to the changes to the css reset between "assets" 0.3.0 and 1.0.0 https://gist.github.com/cowills/a868cd959f57be1b70a313b57a8dbe2b 

this PR on the left, current doc site on the right:

<img width="1680" alt="Screen Shot 2019-05-23 at 10 21 54 AM" src="https://user-images.githubusercontent.com/48567940/58273013-a02c0b80-7d44-11e9-9ffe-52aa00e239d6.png">

<img width="1673" alt="Screen Shot 2019-05-23 at 10 21 47 AM" src="https://user-images.githubusercontent.com/48567940/58273014-a02c0b80-7d44-11e9-9690-2e3f98089d21.png">
