### PR TITLE
Remove installation instructions from API tab

### DIFF
--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -362,67 +362,6 @@ Accordions are built from two components, **CdrAccordion** and **CdrAccordionIte
 ### CdrAccordionItem
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[1].api.events" />
 
-## Installation
-
-Resources are available within the [CdrAccordion package](https://www.npmjs.com/package/@rei/cdr-accordion):
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-accordion`
-- Component styles: `cdr-accordion.css`
-
-<br />
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrAccordion** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-accordion
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS
-import "@rei/cdr-accordion/dist/cdr-accordion.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-accordion>
-    <cdr-accordion-item
-      id="default-example"
-      label="This is the label text"
-    >
-      This is the accordion content.
-    </cdr-accordion-item>
-  </cdr-accordion>
-</template>
-
-<script>
-  import { CdrAccordion, CdrAccordionItem } from "@rei/cdr-accordion";
-
-  export default {
-    ...
-    components: {
-      CdrAccordion,
-      CdrAccordionItem
-    }
-  }
-</script>
-```
-
 ## Usage
 
 ### Style

--- a/docs/components/block-quote/README.md
+++ b/docs/components/block-quote/README.md
@@ -124,18 +124,6 @@
                         "description": "Sets the quote attribution text."
                     }
                 ],
-                "installation": [
-                    {
-                        "name": "@rei/cdr-quote",
-                        "type": "Node module package",
-                        "description": "Import the component into your project"
-                    },
-                    {
-                        "name": "cdr-quote.css",
-                        "type": "Style sheet",
-                        "description": "Component specific styles"
-                    }
-                ]
             }
         }],
         "version": "1.0.0"
@@ -241,66 +229,6 @@ When block quotes are displayed in at XS breakpoints, the text will use a smalle
 ## Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
-
-## Installation
-
-Resources are available within the [CdrQuote package:](https://www.npmjs.com/package/@rei/cdr-quote)
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-quote`
-- Component styles: `cdr-quote.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrQuote** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-import "@rei/cdr-quote/dist/cdr-quote.css";
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-link/dist/cdr-quote.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-quote
-     cite="https://www.rei.com/stewardship"
-     summary="As a co-op, we’re a different kind of company.
-     We put purpose before profits and act with the long-term
-     interests of our members in mind. Being a co-op also means
-     we engage with our community and believe in collective
-     accountability."
-    citation="REI Stewardship"
- />
-</template>
-
-<script>
-import { CdrQuote } from '@rei/cdr-quote';
-export default {
-  ...
-  components: {
-     CdrQuote
-  }
-}
-</script>
-```
 
 </cdr-doc-table-of-contents-shell>
 </template>

--- a/docs/components/breadcrumb/README.md
+++ b/docs/components/breadcrumb/README.md
@@ -103,18 +103,6 @@
                 "description": "Sets the ratio between breadcrumb path width and container width when truncation will occur at the XS breakpoint."
               }
             ],
-            "installation": [
-              {
-                "name": "@rei/cdr-breadcrumb",
-                "type": "Node module package",
-                "description": "Import the component into your project"
-              },
-              {
-                "name": "cdr-breadcrumb.css",
-                "type": "css",
-                "description": "Component specific styles"
-              }
-            ]
           }
         }
       ],
@@ -266,80 +254,6 @@ Truncate breadcrumbs left to right to show the final two links in the trail, so 
 ## Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props"/>
-
-## Installation
-
-Resources are available within the [CdrBreadcrumb package](https://www.npmjs.com/package/@rei/cdr-breadcrumb):
-
-<cdr-doc-api type="installation" />
-
-  - Component: `@rei/cdr-breadcrumb`
-  - Component styles: `cdr-breadcrumb.css`
-
-<br>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrBreadcrumb** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-breadcrumb
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-breadcrumb/dist/cdr-breadcrumb.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-breadcrumb :items="breadcrumbItems"/>
-</template>
-
-<script>
-import { CdrBreadcrumb } from '@rei/cdr-breadcrumb';
-export default {
-
-  components: {
-     CdrBreadcrumb
-  },
-  data () {
-    breadcrumbItems: [
-      {
-        item: {
-          name: ‘Great GrandParent Page’,
-          url: “<UrlBreadcrumb1>”
-        }
-      },
-      {
-        item: {
-          name: “Grandparent Page”,
-          url: “<UrlBreadcrumb2>”
-        }
-      }
-      {
-        item: {
-          name: “Parent Page”,
-          url: “<UrlBreadcrumb3>”
-        }
-      }
-    ]
-  }
-}
-</script>
-```
 
 ## Usage
 

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -172,18 +172,6 @@
             "description": "Sets the innerHTML for CdrButton. This is for the icon."
           }
         ],
-        "installation": [
-          {
-            "name": "@rei/cdr-button",
-            "type": "Node module package",
-            "description": "Import the component into your project"
-          },
-          {
-            "name": "cdr-button.css",
-            "type": "Style sheet",
-            "description": "Component specific styles"
-          }
-        ]
         }
       }
     ],
@@ -445,64 +433,6 @@ Apply the following use cases when deciding when to use links as anchors or butt
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Installation
-
-Resources are available within the [CdrButton package:](https://www.npmjs.com/search?q=cdr-button)
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-button`
-- Component styles: `cdr-button.css`
-
-<br />
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrButton** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-button
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-button/dist/cdr-button.css";
-```
-
-### 3. Add Component to a Template
-
-In this example we’ll create a medium-sized primary button, which is the default.
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-button
-    type="button"
-  >
-    Add to cart
-  </cdr-button>
-</template>
-
-<script>
-import { CdrButton } from '@rei/cdr-button';
-export default {
-  ...
-  components: {
-     CdrButton  
-  }
-}
-</script>
-```
-
 ## Usage
 
 ### Size Prop
@@ -576,8 +506,8 @@ In the below example, a "Download" button is rendered as a button with icon and 
 </template>
 
 <script>
-import { CdrButton } from '@rei/cdr-button';
-import { CdrIcon } from '@rei/cdr-icon';
+import { CdrButton } from '@rei/cedar';
+import { CdrIcon } from '@rei/cedar';
 export default {
   ...
   components: {
@@ -625,7 +555,7 @@ The **CdrButton** package includes two specific icon-only variants. **CdrCloseBu
 </template>
 
 <script>
-import { CdrCloseButton } from '@rei/cdr-button';
+import { CdrCloseButton } from '@rei/cedar';
 
 export default {
   ...

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -506,8 +506,7 @@ In the below example, a "Download" button is rendered as a button with icon and 
 </template>
 
 <script>
-import { CdrButton } from '@rei/cedar';
-import { CdrIcon } from '@rei/cedar';
+import { CdrButton, CdrIcon } from '@rei/cedar';
 export default {
   ...
   components: {

--- a/docs/components/caption/README.md
+++ b/docs/components/caption/README.md
@@ -295,61 +295,6 @@ Caption stays left aligned with body copy regardless of the width of the media.
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-
-## Installation
-
-Resources are available within the [CdrCaption package](https://www.npmjs.com/package/@rei/cdr-caption)
-
-- Component: `@rei/cdr-caption`
-- Component styles: `cdr-caption.css`
-
-<br />
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM 
-
-Install the **CdrCaption** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-text
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required css.
-import "@rei/cdr-caption/dist/cdr-caption.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-caption
-     summary="Lorem ipsum dolor sit amet elit."
-     credit="Lorem ipsum dolor sit"
-   />
-
-</template>
-
-<script>
-import { CdrCaption } from '@rei/cdr-caption';
-export default {
-  ...
-  components: {
-     CdrCaption  
-  }
-}
-</script>
-```
-
 ## Usage
 
 The **CdrCaption** component is developed to work within a composition with other components; however composition-type components have not been developed yet.

--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -173,18 +173,6 @@
                         "description": "$emit event fired on check/uncheck."
                     }
                 ],
-                "installation": [
-                    {
-                        "name": "@rei/cdr-checkbox",
-                        "type": "Node module package",
-                        "description": "Import the component into your project"
-                    },
-                    {
-                        "name": "cdr-checkbox.css",
-                        "type": "Style sheet",
-                        "description": "Component specific styles"
-                    }
-                ]
             }
         }],
         "version": "1.0.0"
@@ -383,60 +371,6 @@ Checkboxes work independently from each other:
 ## Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
-
-## Installation
-
-Resources are available within the [CdrCheckbox package:](https://www.npmjs.com/search?q=cdr-checkbox)
-
-- Component: `@rei/cdr-checkbox`
-- Component styles: `cdr-checkbox.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrCheckbox** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-checkbox
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-link/dist/cdr-checkbox.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-checkbox
-    v-model="model"
-  >
-    True
-  </cdr-checkbox>
-</template>
-
-<script>
-import { CdrCheckbox } from '@rei/cdr-checkbox;
-export default {
-  ...
-  components: {
-     CdrCheckbox,
-  }
-}
-</script>
-```
 
 ## Usage
 

--- a/docs/components/cta/README.md
+++ b/docs/components/cta/README.md
@@ -341,60 +341,6 @@ To construct consistent and universal Call to Actions across the site:
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Installation
-
-Resources are available with the [CdrCta package](https://www.npmjs.com/package/@rei/cdr-cta):
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-cta`
-- Component styles: `cdr-cta.css`
-
-<br />
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrCta** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-cta
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS
-import "@rei/cdr-cta/dist/cdr-cta.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-...
-  <cdr-cta href="rei.com"></cdr-cta>
-...
-</template>
-
-<script>
-import { CdrCta } from '@rei/cdr-cta';
-export default {
-  ...
-  components: {
-    CdrCta
-  }
-}
-</script>
-```
-
 ## Usage
 
 This example code renders a full width `cdr-cta`, with the `elevated` modifier and the `sale` theme.

--- a/docs/components/data-tables/README.md
+++ b/docs/components/data-tables/README.md
@@ -204,18 +204,6 @@
                 "description": "Sets the innerHTML for the <tbody> element. Includes default slot content."
               }
             ],
-            "installation": [
-              {
-                "name": "@rei/cdr-data-table",
-                "type": "Node module package",
-                "description": "Import the component into your project"
-              },
-              {
-                "name": "cdr-data-table.css",
-                "type": "Style sheet",
-                "description": "Component specific styles"
-              }
-            ]
           }
         }
       ]
@@ -437,66 +425,6 @@ Data Table must have row headers and more than two columns of content, then the 
 ## Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
-
-## Installation
-
-Resources are available within the [CdrDataTable package:](https://www.npmjs.com/search?q=cdr-data-table)
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-data-table`
-- Component styles: `cdr-data-table.css`
-
-<br />
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrDataTable** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-data-table
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-data-table/dist/cdr-data-table.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-data-table
-    :col-headers="colHeaders"
-    :row-headers="rowHeaders"
-    :row-data="rowData"
-    :key-order="keyOrder"
-  />
-</template>
-
-<script>
-import { CdrDataTable } from '@rei/cdr-data-table';
-export default {
-  ...
-  components: {
-     CdrDataTable  
-  }, 
-  data() {
-    ...
-  },
-}
-</script>
-```
 
 ## Usage
 

--- a/docs/components/grid/README.md
+++ b/docs/components/grid/README.md
@@ -1173,66 +1173,6 @@ Grids are built from two components, **CdrRow** and **CdrCol**.
 ### CdrCol
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[1].api.slots" :slots-getting-started-link="false" />
 
-## Installation
-
-Resources are available within the [CdrGrid package](https://www.npmjs.com/package/@rei/cdr-grid):
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-grid`
-- Component styles: `cdr-grid.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrGrid** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-grid
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-grid/dist/cdr-grid.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-row>
-    <cdr-col>
-      ...
-    </cdr-col>
-    <cdr-col>
-      ...
-    </cdr-col>
-  </cdr-row>
-</template>
-
-<script>
-import { CdrRow, CdrCol } from '@rei/cdr-grid';
-export default {
-  ...
-  components: {
-     CdrRow,
-     CdrCol  
-  }
-}
-</script>
-```
-
 ## Usage
 
 **CdrRow** functions as a flexbox container, and **CdrCol** functions as a flexbox item.

--- a/docs/components/headings/README.md
+++ b/docs/components/headings/README.md
@@ -300,58 +300,6 @@ Responsive heading font sizes are the default for heading levels except subheadi
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Installation
-
-Resources are available within the [CdrText package](https://www.npmjs.com/package/@rei/cdr-text)
-
-- Component: `@rei/cdr-text`
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrText** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-text
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import '@rei/cdr-assets/dist/cdr-core.css';
-import '@rei/cdr-assets/dist/cdr-fonts.css';
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-text
-    modifier="body"
-  >
-    For long-form content like expert advice articles or co-op journal entries.
-  </cdr-text>
-</template>
-
-<script>
-import { CdrText } from '@rei/cdr-text';
-export default {
-  ...
-  components: {
-     CdrText  
-  }
-}
-</script>
-```
-
 ## Usage
 
 The **CdrText** component allows for styling any html element with available text styles. Visual style and semantic meaning are managed independently by providing: 

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -288,57 +288,6 @@ Ensure that icons use contrast ratio of 4.5:1 between icon color and background 
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Installation
-
-Resources are available within the [CdrIcon package](https://www.npmjs.com/package/@rei/cdr-icon):
-
-- Component: `@rei/cdr-icon`
-- Component styles: `cdr-icon.css`
-
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrIcon** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-icon
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```bash
-// import your required CSS.
-import '@rei/cdr-icon/dist/cdr-icon.css';
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  ...
-    <icon-arrow-down />
-  ...
-</template>
-
-<script>
-import { IconArrowDown } from '@rei/cdr-icon';
-export default {
-  ...
-  components: {
-     IconArrowDown
-  }
-}
-</script>
-```
-
 ## Usage
 
 The **CdrIcon** package contains many different components:
@@ -372,7 +321,7 @@ _App.vue (base template)_
 </template>
 
 <script>
-import { CdrIconSprite } from '@rei/cdr-icon';
+import { CdrIconSprite } from '@rei/cedar';
 
 ...
 components: {
@@ -392,7 +341,7 @@ _Child.vue (any descendant component of App.vue above)_
 </template>
 
 <script>
-import { CdrIcon } from '@rei/cdr-icon';
+import { CdrIcon } from '@rei/cedar';
 
 ...
 components: {
@@ -439,10 +388,6 @@ export default {
 
 This may be the easiest way to use an icon on a page however use this method carefully. This method will increase HTML file size and slow down performance if using a lot of icons.
 
-Requires:
-- Install  `@rei/cdr-icon`
-
-
 ```vue
 <template>
   ...
@@ -452,7 +397,7 @@ Requires:
 </template>
 
 <script>
-import { IconCaretRight, IconClock } from '@rei/cdr-icon';
+import { IconCaretRight, IconClock } from '@rei/cedar';
 
 ...
   components: {
@@ -490,7 +435,7 @@ Use any valid SVG markup in the **CdrIcon** slot.
 </template>
 
 <script>
-@import { CdrIcon } from '@rei/cdr-icon';
+@import { CdrIcon } from '@rei/cedar';
 
 ...
   components: {

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -370,7 +370,7 @@ Within an individual component (there may be a better way to scale this if the c
 
 <script>
 // import the sprite so file-loader will do its magic
-@import iconUrl from '@rei/cdr-assets/dist/cdr-icons.svg`;
+import iconUrl from '@rei/cdr-assets/dist/cdr-icons.svg`;
 
 export default {
   ...
@@ -435,7 +435,7 @@ Use any valid SVG markup in the **CdrIcon** slot.
 </template>
 
 <script>
-@import { CdrIcon } from '@rei/cedar';
+import { CdrIcon } from '@rei/cedar';
 
 ...
   components: {

--- a/docs/components/image/README.md
+++ b/docs/components/image/README.md
@@ -372,56 +372,6 @@ Any other properties supplied will be assigned to the root element (native eleme
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Installation
-
-Resources are available within the [CdrImg package](https://www.npmjs.com/package/@rei/cdr-img):
-
-- Component: `@rei/cdr-img`
-- Component styles: `cdr-img.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrImg** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-img
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import '@rei/cdr-img/dist/cdr-img.css';
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-img />
-</template>
-
-<script>
-import { CdrImg } from '@rei/cdr-img';
-export default {
-  ...
-  components: {
-     CdrImg  
-  }
-}
-</script>
-```
-
 ## Usage
 
 ### Ratio

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -542,65 +542,6 @@ This component has compliance with WCAG guidelines by:
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Installation
-
-Resources are available within the [CdrInput package](https://www.npmjs.com/package/@rei/cdr-input):
-
-- Component: `@rei/cdr-input`
-- Component styles: `cdr-input.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrInput** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-input
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-input/dist/cdr-input.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  ...
-     <cdr-input
-       v-model="inputModel"
-       label="Input Label Text"
-       placeholder="Input Placeholder Text"
-     />
-  ...
-</template>
-
-<script>
-import { CdrInput } from '@rei/cdr-input';
-export default {
-  ...
-  components: {
-    CdrInput,
-  },
-  data() {
-    inputModel: ‘Default Value’
-  }
-}
-</script>
-```
-
 ## Usage
 
 The **CdrInput** component requires `v-model` to bind the input value to your data model.  You can also use   `helper-text` to display additional information below the input.

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -84,18 +84,6 @@
                 "description": "Sets the innerHTML for CdrLink. This includes text and html markup for icons."
               }
             ],
-            "installation": [
-              {
-                "name": "@rei/cdr-link",
-                "type": "Node module package",
-                "description": "Import the component into your project"
-              },
-              { 
-                "name": "cdr-link.css", 
-                "type": "css", 
-                "description": "Component specific styles" 
-              }
-            ]
           }
         }
       ],
@@ -300,61 +288,6 @@ WebAIM: Links and Hypertext [Introduction to Links and Hypertext](https://webaim
 ## Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
-
-## Installation
-
-Resources are available within the [CdrLink package](https://www.npmjs.com/package/@rei/cdr-link):
-
-- Component: `@rei/cdr-link`
-- Component styles: `cdr-link.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrLink** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-link
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-link/dist/cdr-link.css";
-
-// If your link will display an icon ensure you also include the icon’s CSS file.
-import "@rei/cdr-link/dist/cdr-icon.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-...
-    <cdr-link href="rei.com">Ten Essentials.</cdr-link>
-...
-</template>
-
-<script>
-import { CdrLink } from '@rei/cdr-link';
-export default {
-  ...
-  components: {
-     CdrLink  
-  }
-}
-</script>
-```
 
 ## Usage
 

--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -372,65 +372,6 @@ WebAIM: [Semantic Structure: Using Lists Correctly](https://webaim.org/technique
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Installation
-
-Resources are available within the [CdrList package](https://www.npmjs.com/package/@rei/cdr-list):
-
-- Component: `@rei/cdr-list`
-- Component styles: `cdr-list.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrList** package using `npm` in your terminal:
-
-_Terminal_
-
-<cdr-doc-code-snippet :line-numbers="false" :copy-button="false">
-
-```bash
-npm i -S @rei/cdr-list
-```
-
-</cdr-doc-code-snippet>
-
-### 2. Import Dependencies
-
-_main.js_
-
-<cdr-doc-code-snippet :line-numbers="false" :copy-button="false">
-
-```javascript
-// import your required CSS.
-import '@rei/cdr-list/dist/cdr-list.css';
-```
-</cdr-doc-code-snippet>
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-list>
-    <li> item one </li>
-    <li> item two </li>
-  </cdr-list>
-</template>
-
-<script>
-import { CdrList } from '@rei/cdr-list';
-export default {
-  components: {
-     CdrList  
-  }
-}
-</script>
-```
-
 ## Usage
 
 Visual style and semantic meaning are managed independently by providing: 

--- a/docs/components/pagination/README.md
+++ b/docs/components/pagination/README.md
@@ -212,74 +212,6 @@ Pagination adapts to a Select component with a native UI dropdown menu on XS bre
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Installation
-
-Resources are available with the [CdrPagination package](https://www.npmjs.com/package/@rei/cdr-pagination):
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-pagination`
-- Component styles: `cdr-pagination.css`
-
-<br />
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrPagination** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-pagination
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS
-import "@rei/cdr-pagination/dist/cdr-pagination.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  ...
-    <cdr-pagination
-      :pages="pageData"
-      :total-pages="pageData.length"
-      v-model="ex1Page"
-    />
-  ...
-</template>
-
-<script>
-import { CdrPagination } from '@rei/cdr-pagination';
-export default {
-  ...
-  components: {
-     CdrPagination  
-  },
-  data() {
-    return {
-      ex1Page: 1,
-      pageData: [
-        { page: 1, url: 'https://www.rei.com/search?page=1' },
-        { page: 2, url: 'https://www.rei.com/search?page=2' },
-        { page: 3, url: 'https://www.rei.com/search?page=3' }
-      ]
-    };
-  },
-}
-</script>
-```
-
 ## Usage
 
 The **CdrPagination** component provides a current page number control and renders a list of links. The current page value should be bound using `v-model` in your app.
@@ -307,7 +239,7 @@ If not using Vue Router (see "Usage with Vue Router" below) you will need to man
 </template>
 
 <script>
-import { CdrPagination } from '@rei/cdr-pagination';
+import { CdrPagination } from '@rei/cedar';
 export default {
   ...
   components: {
@@ -349,7 +281,7 @@ Page URLs still need to be provided for SEO purposes, but the events emitted by 
 </template>
 
 <script>
-import { CdrPagination } from '@rei/cdr-pagination';
+import { CdrPagination } from '@rei/cedar';
 export default {
   ...
   components: {

--- a/docs/components/paragraphs/README.md
+++ b/docs/components/paragraphs/README.md
@@ -222,60 +222,6 @@ Sentinel carries a stronger brand impression with other brand material, and is p
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Installation
-
-Resources are available within the [CdrText package](https://www.npmjs.com/package/@rei/cdr-text)
-
-- Component: `@rei/cdr-text`
-
-<br />
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM 
-
-Install the **CdrText** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -S @rei/cdr-text
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-assets/dist/cdr-core.css";
-import "@rei/cdr-assets/dist/cdr-fonts.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-text
-    modifier="body"
-  >
-    For long-form content like expert advice articles or co-op journal entries.
-  </cdr-text>
-</template>
-
-<script>
-import { CdrText } from '@rei/cdr-text';
-export default {
-  ...
-  components: {
-     CdrText  
-  }
-}
-</script>
-```
-
 ## Usage
 
 The **CdrText** component allows for styling any html element with available text styles. Visual style and semantic meaning are managed independently by providing: 

--- a/docs/components/pull-quote/README.md
+++ b/docs/components/pull-quote/README.md
@@ -122,18 +122,6 @@
                         "description": "Sets the pull quote attribution text."
                     }
                 ],
-                "installation": [
-                    {
-                        "name": "@rei/cdr-quote",
-                        "type": "Node module package",
-                        "description": "Import the component into your project"
-                    },
-                    {
-                        "name": "cdr-quote.css",
-                        "type": "Style sheet",
-                        "description": "Component specific styles"
-                    }
-                ]
             }
         }],
         "version": "1.0.0"
@@ -222,66 +210,6 @@ When a pull quote is displayed in at XS breakpoints, the left border will appear
 ## Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
-
-## Installation
-
-Resources are available within the [CdrQuote package:](https://www.npmjs.com/package/@rei/cdr-quote)
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-quote`
-- Component styles: `cdr-quote.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrQuote** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i @rei/cdr-quote
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-quote/dist/cdr-quote.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-quote
-     tag="aside"
-     modifier="pull"
-     summary="As a co-op, we’re a different kind of company.
-     We put purpose before profits and act with the long-term
-     interests of our members in mind. Being a co-op also means
-     we engage with our community and believe in collective
-     accountability."
- />
-</template>
-
-<script>
-import { CdrQuote } from '@rei/cdr-quote';
-export default {
-  ...
-  components: {
-     CdrQuote
-  }
-}
-</script>
-```
 
 </cdr-doc-table-of-contents-shell>
 </template>

--- a/docs/components/radio/README.md
+++ b/docs/components/radio/README.md
@@ -326,69 +326,6 @@ Radio button labels should:
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events"/>
 
-## Installation
-
-Resources are available within the [CdrRadio package](https://www.npmjs.com/package/@rei/cdr-radio):
-
-- Component: `@rei/cdr-radio`
-- Component styles: `cdr-radio.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrRadio** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-radio
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-radio/dist/cdr-radio.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  <cdr-radio
-    v-model="model"
-    name="ship-pref"
-    value="ship"
-  >
-    Ship to address
-  </cdr-radio>
-  <cdr-radio
-    v-model="model"
-    name="ship-pref"
-    value="pickup"
-  >
-    Pick up in store
-  </cdr-radio>
-</template>
-
-<script>
-import { CdrRadio} from '@rei/cdr-radio';
-export default {
-  ...
-  components: {
-     CdrRadio
-  }
-}
-</script>
-```
-
 ## Usage
 
 The **CdrRadio** component requires `v-model` to track the value of selected radios.

--- a/docs/components/rating/README.md
+++ b/docs/components/rating/README.md
@@ -255,61 +255,8 @@ This component has compliance with WCAG guidelines by:
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Installation
-
-Resources are available within the [CdrRating package:](https://www.npmjs.com/package/@rei/cdr-rating)
-
-<cdr-doc-api type="installation" />
-
-- Component: `@rei/cdr-rating`
-- Component styles: `cdr-rating.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrRating** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i @rei/cdr-rating
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-rating/dist/cdr-rating.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  ...
-     <cdr-rating rating="4.2" count="77" />
-  ...
-</template>
-
-<script>
-import { CdrRating } from '@rei/cdr-rating;
-export default {
-  ...
-  components: {
-     CdrRating  
-  }
-}
-</script>
-```
-
 ## Usage
+
 By default the **CdrRating** component renders the icons in medium size (24px) with the total number of reviews. 
 
 ### Rating Values

--- a/docs/components/tabs/README.md
+++ b/docs/components/tabs/README.md
@@ -301,63 +301,6 @@ Tabs are built from two components, **CdrTabs** and **CdrTabPanel**, which are m
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Installation
-
-Resources are available within the [CdrTabs package](https://www.npmjs.com/package/@rei/cdr-tabs):
-
-- Component: `@rei/cdr-tabs`
-- Component styles: `cdr-tabs.css`
-
-<br/>
-
-To incorporate the required assets for a component, use the following steps:
-
-### 1. Install using NPM
-
-Install the **CdrTabs** package using `npm` in your terminal:
-
-_Terminal_
-
-```bash
-npm i -s @rei/cdr-tabs
-```
-
-### 2. Import Dependencies
-
-_main.js_
-
-```javascript
-// import your required CSS.
-import "@rei/cdr-tabs/dist/cdr-tabs.css";
-```
-
-### 3. Add Component to a Template
-
-_local.vue_
-
-```vue
-<template>
-  ...
-     <cdr-tabs>
-       <cdr-tab-panel name=”tab1”>TAB1 CONTENT GOES HERE</cdr-tab-panel>
-       <cdr-tab-panel name=”tab2”>TAB2 CONTENT GOES HERE</cdr-tab-panel>
-       <cdr-tab-panel name=”tab3”>TAB3 CONTENT GOES HERE</cdr-tab-panel>
-     </cdr-tabs>
-  ...
-</template>
-
-<script>
-import { CdrTabs, CdrTabPanel } from '@rei/cdr-tabs’;
-export default {
-  ...
-  components: {
-     CdrTabs,
-     CdrTabPanel
-  },
-}
-</script>
-```
-
 ## Usage
 
 The `cdr-tab-panel name` property sets the tab display value and is used for reference.


### PR DESCRIPTION
Remove extra frontmatter for installation (unused), update references to package name to @rei/cedar

There are still some references to the old package for stuff around the icon sprite svg -- we've talked about adding those raw files to satchel though.

There are also references to old package names in the changelog tab. How do we want to manage those now? Will each component have it's own changelog still or will we just have one global changelog?