### PR TITLE
add anchors before headings

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,7 +25,8 @@ module.exports = {
     ['@vuepress/google-analytics', { ga: 'UA-129829250-1' }]
   ],
   markdown: {
-    lineNumbers: true
+    lineNumbers: true,
+    anchor: { permalink: true, permalinkBefore: true, permalinkSymbol: '#' } // generate links to headings
   },
   themeConfig: {
     logo: "/doc-site-logo.svg",

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -54,8 +54,9 @@ body {
 }
 
 .header-anchor {
-  // TODO: make pretty :>
-  // display: none;
+  @include cdr-text-header-5;
+  color: 	$cdr-color-text-link-lightmode;
+  text-decoration: none;
 }
 
 .cdr-doc-proving-ground {

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -54,7 +54,8 @@ body {
 }
 
 .header-anchor {
-  display: none;
+  // TODO: make pretty :>
+  // display: none;
 }
 
 .cdr-doc-proving-ground {


### PR DESCRIPTION
adds anchor links to every heading using this feature of vuepress: https://vuepress.vuejs.org/config/#markdown-anchor 

this will make it much easier to share a link directly to part of the docs without having to manually construct the URL (which i find myself doing multiple times a week 🤓

<img width="313" alt="Screen Shot 2019-06-19 at 2 05 04 PM" src="https://user-images.githubusercontent.com/48567940/59800376-5d097d80-929b-11e9-83a2-7e3d33582e94.png">
)

