### PR TITLE
scaffold out release notes section

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -30,7 +30,11 @@ module.exports = {
     nav: [
       {
         text: "Release History",
-        link: "/release-history/"
+        items: [
+          { text: "Summer 2019", link: "/release-history/summer-2019/"},
+          { text: "Spring 2019", link: "/release-history/spring-2019/"},
+          { text: "Archived", link: "/release-history/archived/"}
+        ]
       },
       {
         text: "Getting Started",

--- a/docs/release-history/archived/README.md
+++ b/docs/release-history/archived/README.md
@@ -1,0 +1,237 @@
+---
+{
+  "title": "Release History",
+  "title_metadata": false,
+  "layout": "LayoutArticle",
+  "summary": false,
+  "breadcrumbs": [
+    {
+      "text": ""
+    }
+  ],
+}
+---
+
+<cdr-doc-table-of-contents-shell>
+
+## 19.04.1 Release
+
+### Cedar Tokens
+
+- Released [cdr-tokens](../foundation/tokens/) NPM package v1.0 [view in NPM](https://www.npmjs.com/package/@rei/cdr-tokens)
+  - [Color](../foundation/color/)
+  - [Spacing](../foundation/spacing/)
+  - [Typography](../foundation/typography/)
+
+## 18.12.1 Release
+
+### New Components
+
+- Added new [Pagination](../components/pagination/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.12.2/src/components/pagination)
+  - Component
+  - Styles
+
+### Component Updates
+
+- Updated [Call to Action](../components/cta/) component v1.1 [view in github](https://github.com/rei/rei-cedar/tree/18.12.2/src/components/cta)
+  - Removed **CdrIcon** dependency
+
+### Design Assets
+
+- Sketch library
+  - Published the Sketch library with design assets for the released components above
+
+### Component Updates
+
+- Updated [Buttons](../components/buttons/) component
+  - Deprecated `responsive-size` prop
+  - Updated `size` prop
+- Updated [Icon](../components/icon/) component
+  - Added `size` prop
+  - Updated `modifier` prop
+- Updated [Accordion](../components/accordion/) component CdrIcon dependency, usage
+- Updated [Link](../components/links/) component CdrIcon dependency
+
+
+## 18.11.1 Release
+
+### New Components
+
+- Added new [Tabs](../components/tabs/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.11.1/src/components/tabs)
+  - Component
+  - Styles
+
+- Added new [Data Tables](../components/data-tables/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.11.1/src/components/dataTable)
+  - Component
+  - Styles
+
+- Added new [Inputs](../components/input/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.11.1/src/components/input)
+  - Component
+  - Styles
+
+- Added new [Ratings](../components/rating/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.11.1/src/components/rating)
+  - Component
+  - Styles
+
+### Component Updates
+
+- Updated [Buttons](../components/buttons/) component stylesheet import to fix server-side rendering
+- Updated [CTA](../components/cta/) component stylesheet import to fix server-side rendering
+- Updated [Accordion](../components/accordion/) component stylesheet import to fix server-side rendering
+- Updated [Breadcrumb](../components/breadcrumb/) component CdrAssets dependency
+
+### Design Assets
+
+- Sketch library 
+  - Published the Sketch library with design assets for the released components above 
+
+### Documentation Updates
+
+- Accessibility
+  - Article describing how Accessibility fits in as a foundation of the design system; including info on why it matters, how to make your products accessible and other related topics 
+
+
+## 18.09.2 Release
+
+### New Components
+
+- Added new [Block Quote](../components/block-quote/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.09.2/src/components/quote)
+  - Component
+  - Styles
+- Added new [Caption](../components/caption/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.09.2/src/compositions/caption)
+  - Component
+  - Styles
+- Added new [Pull Quote](../components/pull-quote/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.09.2/src/components/quote)
+  - Component
+  - Styles
+
+### Component Updates
+
+- Updated [Buttons](../components/buttons/) component styling to remove extra grey border around all variants (PLIB-3770)
+- Updated [Breadcrumb](../components/breadcrumb/) component to address an issue with the ‘offsetWidth’ property (PLIB-3659)
+
+### Design Assets
+
+- Sketch library
+  - Published the Sketch library with design assets for the released components above
+
+### Documentation Updates
+
+- Spacing
+  - Article describing the use of spacing as a foundation of the design system
+- Component documentation updates to improve content consistency and usability including (but not limited to) the following:
+  - Updated spacing to improve readability
+  - Added a “See also” section to applicable component pages to highlight related content
+  - Consolidated accessibility info and moved this to the Overview tab for each component
+  - Updated image styling on component and article pages to improve consistency and readability
+
+## 18.09.1 Release
+
+### New Components
+
+- Added new [Icons](../components/icon/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.09.1/src/components/icon)
+  - Component
+  - Styles
+
+## MVP Release
+
+[Cedar MVP Release](https://github.com/rei/rei-cedar/tree/18.08.1)
+
+### Components
+
+- Added new [Accordion](/components/accordion/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.08.1/src/components/accordion)
+  - Component
+  - Styles
+- Added new [Checkbox](/components/checkboxes/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.08.1/src/components/checkbox)
+  - Component
+  - Styles
+- Added new [CTA](/components/cta/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.08.1/src/components/cta)
+  - Component
+  - Styles
+- Added new [Image](/components/image/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.08.1/src/components/image)
+  - Component
+  - Styles
+- Added new [Radio](/components/radio/) component v1.0 [view in github](https://github.com/rei/rei-cedar/tree/18.08.1/src/components/radio)
+  - Component
+  - Styles
+
+### Design Assets
+
+- Sketch library
+  - Published the Sketch library with design assets for the released components above
+
+### Documentation Updates
+
+- Iconography
+  - Article describing the use of iconography as a foundation of the design system
+- Motion
+  - Article describing the use of motion as a foundation of the design system
+- Experience Principles
+  - Article describing the principles of customer experience at the foundation of Cedar
+
+## Beta Release
+
+[Cedar Beta Release](https://github.com/rei/rei-cedar/tree/18.07.2)
+
+### Components
+
+- Added new Breadcrumb component v1.0 ([CdrBreadcrumb](https://github.com/rei/rei-cedar/tree/18.07.2/src/components/breadcrumb))
+  - Component
+  - Styles
+- Added new Button component v1.0 ([CdrButton](https://github.com/rei/rei-cedar/tree/18.07.2/src/components/button))
+  - Component
+  - Styles
+- Added new Grid component v1.0 ([CdrGrid](https://github.com/rei/rei-cedar/tree/18.07.2/src/components/grid))
+  - Row component
+  - Col Component
+  - Styles
+- Added new List component v1.0 ([CdrList](https://github.com/rei/rei-cedar/tree/18.07.2/src/components/list))
+  - Component
+  - Styles
+
+### Design Assets
+
+- Sketch library 
+  - Published the Sketch library with design assets for the released components above
+
+### Documentation Updates
+
+- About Cedar
+  - Article providing a high level overview of Cedar and the benefits of adoption 
+- Getting Started as an Adopting Team
+  - Article providing instructions for how to get started as an adopting team
+- Typography page
+  - Article describing the use of typography as a foundation of the design system
+
+<hr/>
+
+## Alpha Release
+
+[Cedar Alpha Release](https://github.com/rei/rei-cedar/tree/18.06.1)
+
+### Components
+
+- Released of V1 Link component ([CdrLink](https://www.npmjs.com/package/@rei/cdr-link))
+- Released of V1 Text component ([CdrText](https://www.npmjs.com/package/@rei/cdr-text))
+  - supports [paragraphs](../components/paragraphs/README.md)
+  - supports [headings](../components/headings/README.md)
+
+### Design Assets
+
+- Sketch library
+  - Published the Sketch library with design assets for the released components above
+
+### Documentation Updates
+
+- Cedar Home page
+  - Alpha version of Cedar Design System Home page
+- Browser Support
+  - Article outlining OS / Browser combinations currently supported by Cedar
+- Getting Started as a Designer
+  - Article providing step-by-step instructions for how to get started as a designer
+- Getting Started as a Developer
+  - Article providing step-by-step instructions for how to get started as a developer
+- Color page
+  - Article describing the use of color as a foundation of the design system
+
+</cdr-doc-table-of-contents-shell>

--- a/docs/release-history/spring-2019/README.md
+++ b/docs/release-history/spring-2019/README.md
@@ -1,0 +1,19 @@
+---
+{
+  "title": "Spring 2019: Cedar Tokens",
+  "title_metadata": false,
+  "layout": "LayoutArticle",
+  "summary": false,
+  "breadcrumbs": [
+    {
+      "text": "Release Notes"
+    }
+  ],
+}
+---
+
+<cdr-doc-table-of-contents-shell>
+
+cdr-tokens release notes
+
+</cdr-doc-table-of-contents-shell>

--- a/docs/release-history/summer-2019/README.md
+++ b/docs/release-history/summer-2019/README.md
@@ -1,0 +1,19 @@
+---
+{
+  "title": "Summer 2019: Single Package",
+  "title_metadata": false,
+  "layout": "LayoutArticle",
+  "summary": false,
+  "breadcrumbs": [
+    {
+      "text": "Release Notes"
+    }
+  ],
+}
+---
+
+<cdr-doc-table-of-contents-shell>
+
+single package release notes
+
+</cdr-doc-table-of-contents-shell>


### PR DESCRIPTION
trying to create a more accessible place to store stuff like this:
https://confluence.rei.com/display/TP/v1+Token+Migration 
https://gist.github.com/cowills/b8f023ac4e4f8801540525a182aa99b3

Presumably we would keep the last couple releases in the dropdown, and move the rest to an "archived" state of some sort. 

I'm retroactively calling the cdr-tokens 1.0.0 release "spring 2019" for simplicity but i have absolutely no opinions on the naming 🙉🙊🙈