### PR TITLE
fix sidebar nesting

### DIFF
--- a/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
+++ b/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
@@ -342,7 +342,9 @@ export default {
   }
 
   .cdr-doc-local-anchor-nav__link--child {
-    padding-left: $cdr-space-two-x;
+    // !important needed to fix precedence issue with cdr-link defaults
+    // TODO: fix CSS loading order so custom CSS is loaded after Cedar 
+    padding-left: $cdr-space-two-x !important;
 
     &:before {
       content: '\2014'; // &mdash;


### PR DESCRIPTION
Doing this as a quick fix so that the doc site is ready to deploy for the release. Seems like any CSS written in the .vue components is being loaded before cedar.css, causing cdr-link to take precedence here. 

