### PR TITLE
Release cleanup, docsite improvements

### DIFF
--- a/docs/.vuepress/components/cdr-doc-table-of-contents-shell.vue
+++ b/docs/.vuepress/components/cdr-doc-table-of-contents-shell.vue
@@ -59,6 +59,6 @@ export default {
   .cdr-doc-table-of-contents-shell__navigation {
     flex-shrink: 0;
     min-width: 0;
-    width: 200px;
+    width: 131px;
   }
 </style>

--- a/docs/.vuepress/theme/styles/cdr-doc-tokens.scss
+++ b/docs/.vuepress/theme/styles/cdr-doc-tokens.scss
@@ -12,7 +12,7 @@ $cdr-doc-background-color-default: $cdr-color-background-lightest;
 $cdr-doc-border-separator: solid 1px $partly-cloudy;
 $cdr-doc-border-radius-default: 4px;
 
-$cdr-doc-content-max-width: 900px;
+$cdr-doc-content-max-width: 950px;
 $cdr-doc-long-form-text-max-line-length: 630px;
 $cdr-doc-long-form-text-top-and-bottom-inset-space: 48px; // not a token?
 

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -7,7 +7,7 @@
 @import '../../../../node_modules/@rei/cedar/dist/cedar.css';
 
 $side-navigation-logo-width: 162px;
-$side-navigation-width: 262px;
+$side-navigation-width: 234px;
 
 html,
 body {
@@ -51,6 +51,7 @@ body {
 .cdr-doc-page-shell__body {
   background: $cdr-doc-background-color-main-body;
   flex: 1 1 100%;
+  overflow-x: scroll;
 }
 
 .header-anchor {

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -8,6 +8,7 @@
 
 $side-navigation-logo-width: 162px;
 $side-navigation-width: 234px;
+$side-navigation-width-sm: $side-navigation-logo-width + 24px;
 
 html,
 body {
@@ -24,6 +25,7 @@ body {
 .cdr-doc-page-shell__side-navigation {
   flex: 0 0 $side-navigation-width;
   width: $side-navigation-width;
+  z-index: 120;
 }
 
 .cdr-doc-side-navigation {
@@ -36,7 +38,20 @@ body {
   width: $side-navigation-width;
 }
 
+
+@media only screen and (max-width: $cdr-breakpoint-sm) {
+  .cdr-doc-page-shell__side-navigation {
+    flex: 0 0 $side-navigation-width-sm;
+    width: $side-navigation-width-sm;
+  }
+  
+  .cdr-doc-side-navigation {
+    width: $side-navigation-width-sm;
+  }
+}
+
 .cdr-doc-side-navigation__logo-wrap {
+  background: $cdr-doc-background-color-main-body;
   align-items: center;
   display: flex;
   justify-content: center;
@@ -51,7 +66,6 @@ body {
 .cdr-doc-page-shell__body {
   background: $cdr-doc-background-color-main-body;
   flex: 1 1 100%;
-  overflow-x: scroll;
 }
 
 .header-anchor {

--- a/docs/release-notes/summer-2019/README.md
+++ b/docs/release-notes/summer-2019/README.md
@@ -30,7 +30,7 @@ Assuming you are already consuming the multi-package form of the Cedar Vue compo
 
 Note that these steps will differ slightly depending on whether you are updating a micro-site or a component. Please reach out to the Cedar team if you have any questions, concerns, or need assistance with upgrading.
 
-#### For a micro-site
+#### For A Micro-Site
 
 1. Install the new Cedar single-package module: `npm install --save @rei/cedar`
 
@@ -51,16 +51,23 @@ import { CdrButton, CdrLink } from '@rei/cedar';
 ```
 /* old CSS import example: */
 
-@import '@rei/cdr-assets/dist/cdr-fonts.css'; // import Cedar fonts
-@import '@rei/cdr-assets/dist/cdr-core.css'; // import Cedar reset and utility classes
+// import Cedar fonts
+@import '@rei/cdr-assets/dist/cdr-fonts.css';
 
-@import '@rei/cdr-COMPONENT_NAME/dist/cdr-COMPONENT_NAME.css'; // import CSS for individual components
+// import Cedar reset and utility classes
+@import '@rei/cdr-assets/dist/cdr-core.css';
+
+// import CSS for individual components
+@import '@rei/cdr-COMPONENT_NAME/dist/cdr-COMPONENT_NAME.css'; 
 @import '@rei/cdr-button/dist/cdr-button.css'; // etc.
 
 /* new CSS import example: */
 
-@import '@rei/cedar/dist/cdr-fonts.css'; // import Cedar fonts
-@import '@rei/cedar/dist/cedar.css'; // import Cedar reset, utility classes, and component CSS
+// import Cedar fonts
+@import '@rei/cedar/dist/cdr-fonts.css'; 
+
+// import Cedar reset, utility classes, and component CSS
+@import '@rei/cedar/dist/cedar.css'; 
 ```
 
 4. Delete the old `@rei/cdr-` dependencies from your package.json (excluding `cdr-tokens` if you are using that), run npm install, and verify that your app builds correctly


### PR DESCRIPTION
- minor formatting updates to the release notes
- removes some pixels from the left and right navs and adds them to the body content. this helps create more space for stuff like code blocks and tables
- removes even more pixels from the sidenav on screens < 768px. 
- fixes the body content scroll overflow issue on narrow window sizes (its still weird, but now it's a lil less weird)

This doc site is very unique in that it's an instance of a non-responsive flexbox layout, there can't be too many of those out there 😆  

Fixes #349

I don't think these are perfect solutions, but poking around the site locally it does seem to improve the experience. 