### PR TITLE
fix cedar CSS loading order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 .DS_Store
 
 docs/.vuepress/dist/
+
+docs/.vuepress/public/cedar.css

--- a/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
+++ b/docs/.vuepress/components/cdr-doc-local-anchor-nav.vue
@@ -342,9 +342,7 @@ export default {
   }
 
   .cdr-doc-local-anchor-nav__link--child {
-    // !important needed to fix precedence issue with cdr-link defaults
-    // TODO: fix CSS loading order so custom CSS is loaded after Cedar 
-    padding-left: $cdr-space-two-x !important;
+    padding-left: $cdr-space-two-x;
 
     &:before {
       content: '\2014'; // &mdash;

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -18,7 +18,14 @@ module.exports = {
         rel: "icon",
         href: "/favicon.ico"
       }
-    ]
+    ],
+    [
+      "link",
+      {
+        rel: "stylesheet",
+        href: "/cedar.css"
+      }
+    ],
   ],
   ga: '',
   plugins: [

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -35,6 +35,7 @@ body {
   height: 100vh;
   overflow-y: scroll;
   width: $side-navigation-width;
+  background-color: $cdr-doc-background-color-main-body;
 }
 
 

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -4,7 +4,6 @@
 @import 'examples.scss';
 
 @import '../../../../node_modules/@rei/cedar/dist/cdr-fonts.css';
-@import '../../../../node_modules/@rei/cedar/dist/cedar.css';
 
 $side-navigation-logo-width: 162px;
 $side-navigation-width: 234px;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "This is the API documentation site for REI Cedar 2 Framework components",
   "private": false,
   "scripts": {
-    "dev": "vuepress dev docs",
-    "build": "cross-env NODE_ENV=production vuepress build docs"
+    "dev": "npm run copy-cedar && vuepress dev docs",
+    "build": "npm run copy-cedar && cross-env NODE_ENV=production vuepress build docs",
+    "copy-cedar": "cp ./node_modules/@rei/cedar/dist/cedar.css ./docs/.vuepress/public/cedar.css"
   },
   "author": "REI Software Engineering",
   "license": "ISC",


### PR DESCRIPTION
vuepress for some reason is loading .vue style blocks `_before_` it is loading `theme.scss`, which means that the cedar css was being loaded after our custom styles instead of before them. This change makes `cedar.css` load before the rest of the css. 

I couldn't find any obvious way in the vuepress docs to control this.

If we end up putting cedar.css on satchel then this can obviously leverage that for additional cache magic :>