### PR TITLE
Link event notes

### DIFF
--- a/docs/.vuepress/components/ApiEvent.vue
+++ b/docs/.vuepress/components/ApiEvent.vue
@@ -7,7 +7,7 @@
         <cdr-col
           span="12 6@sm"
         >
-          <div>
+          <div v-if="apiEvent.name">
             <p :aria-labelledby="'eventName' + index" class="event-name">{{ apiEvent.name }}</p>
             <p :id="'eventName' + index" class="event-label">name</p>
           </div>
@@ -15,7 +15,7 @@
         <cdr-col
           span="12 6@sm"
         >
-          <div>
+          <div v-if="apiEvent.arguments">
             <p :aria-labelledby="'eventType' + index" class="event-type">{{ apiEvent.arguments }}</p>
             <p :id="'eventType' + index" class="event-label">arguments</p>
           </div>

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -86,8 +86,6 @@
             ],
             "events": [
               {
-                "name": "",
-                "arguments": "",
                 "description": "All event listeners are passed through to/from the component."
               }
             ]

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -84,6 +84,13 @@
                 "description": "Sets the innerHTML for CdrLink. This includes text and html markup for icons."
               }
             ],
+            "events": [
+              {
+                "name": "",
+                "arguments": "",
+                "description": "All event listeners are passed through to/from the component."
+              }
+            ]
           }
         }
       ],
@@ -288,6 +295,10 @@ WebAIM: Links and Hypertext [Introduction to Links and Hypertext](https://webaim
 ## Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
+
+## Events
+
+<cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events"/>
 
 ## Usage
 


### PR DESCRIPTION
Add logic to not show event name/args when not present. Then we can use the same "Events" API section to note that events are passed through.