### PR TITLE
Fix error

### DIFF
--- a/docs/.vuepress/components/cdr-doc-example-code-pair.vue
+++ b/docs/.vuepress/components/cdr-doc-example-code-pair.vue
@@ -57,7 +57,7 @@
     props: {
       backgroundToggle: {
         type: Boolean,
-        default: true
+        default: false
       },
       backgroundColors: {
         type: Object,

--- a/docs/.vuepress/components/cdr-doc-html-example-list.vue
+++ b/docs/.vuepress/components/cdr-doc-html-example-list.vue
@@ -1,35 +1,35 @@
 <template>
   <div class="cdr-doc-html-example-list" :class="{'cdr-doc-html-example-list--not-interactive': !interactive }">
-    <div class="cdr-doc-html-example-list__item" 
+    <div class="cdr-doc-html-example-list__item"
           :class="'cdr-doc-html-example-list__item-background--' + backgroundToggleStates[slotLabel]"
           v-for="slotContent, slotLabel in $slots">
       <div class="cdr-doc-html-example-list__item-background-toggle" v-if="backgroundToggle">
-        <label class="cdr-doc-item-background-toggle__button" 
-                :class="{'cdr-doc-item-background-toggle__button--active': backgroundToggleStates[slotLabel] === 'light'}" 
+        <label class="cdr-doc-item-background-toggle__button"
+                :class="{'cdr-doc-item-background-toggle__button--active': backgroundToggleStates[slotLabel] === 'light'}"
                 :for="'cdr-doc-html-example-list__toggle-light-' + slotLabel + instanceId">
-          <input 
+          <input
             class="cdr-doc-item-background-toggle__input"
-            type="radio" 
+            type="radio"
             :id="'cdr-doc-html-example-list__toggle-light-' + slotLabel + instanceId"
             value="light"
             v-model="backgroundToggleStates[slotLabel]">
             Light
         </label>
         <label class="cdr-doc-item-background-toggle__button"
-                :class="{'cdr-doc-item-background-toggle__button--active': backgroundToggleStates[slotLabel] === 'dark'}" 
+                :class="{'cdr-doc-item-background-toggle__button--active': backgroundToggleStates[slotLabel] === 'dark'}"
                 :for="'cdr-doc-html-example-list__toggle-dark-' + slotLabel + instanceId">
-        <input 
+        <input
           class="cdr-doc-item-background-toggle__input"
-          type="radio" 
+          type="radio"
           :id="'cdr-doc-html-example-list__toggle-dark-' + slotLabel + instanceId"
           value="dark"
           v-model="backgroundToggleStates[slotLabel]">
           Dark
         </label>
       </div>
-      <span 
-        class="cdr-doc-html-example-list__item-label" 
-        v-if="(exampleCount > 1 && showExampleLabels) || 
+      <span
+        class="cdr-doc-html-example-list__item-label"
+        v-if="(exampleCount > 1 && showExampleLabels) ||
               label">
         {{ label || slotLabel }}
       </span>
@@ -51,7 +51,7 @@
     props: {
       backgroundToggle: {
         type: Boolean,
-        default: true
+        default: false
       },
       backgroundColors: {
         type: Object,
@@ -226,20 +226,20 @@
     &:first-child {
       border-radius: $cdr-doc-border-radius-default 0 0 $cdr-doc-border-radius-default;
     }
-    
+
     &:last-child {
       border-radius: 0 $cdr-doc-border-radius-default $cdr-doc-border-radius-default 0;
       border-right-width: 1px;
     }
   }
-  
+
   .cdr-doc-item-background-toggle__button--active {
     background: $partly-cloudy;
   }
 
   .cdr-doc-item-background-toggle__input {
     position: absolute !important;
-    height: 1px; width: 1px; 
+    height: 1px; width: 1px;
     overflow: hidden;
     clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
     clip: rect(1px, 1px, 1px, 1px);

--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -235,7 +235,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
 
 Border aligns to the title text and expand/collapse icon.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/accordion" :sandbox-data="$page.frontmatter.sandboxData" :model="{ borderAligned1: false, borderAligned2: false, borderAligned3: false }">
+<cdr-doc-example-code-pair repository-href="/src/components/accordion" :sandbox-data="$page.frontmatter.sandboxData" :model="{ borderAligned1: false, borderAligned2: false, borderAligned3: false }">
 
 ```vue
   <cdr-accordion

--- a/docs/components/block-quote/README.md
+++ b/docs/components/block-quote/README.md
@@ -143,7 +143,7 @@
 
 Default block quote can be used with the following HTML tags: `<p>`, `<div>`, `<aside>`. This is responsive with styles for XS breakpoint
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/quote" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/quote" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
 <div>

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -261,7 +261,7 @@ Pair an icon with text to improve recognition about an object or action.
 
 Use to visually communicate an object or action in limited space. Include alternative text to describe what button does.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" :load-sprite="true" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, CdrIcon'})" >
+<cdr-doc-example-code-pair repository-href="/src/components/button" :load-sprite="true" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, CdrIcon'})" >
 
 ```html
   <div>
@@ -285,7 +285,7 @@ Use to visually communicate an object or action in limited space. Include altern
 
 Change the button size based on where button is used. Default size is medium. Small is used for supplemental user actions such as product comparison or filter. Large is used for &quot;Add to cart&quot; on product pages or Call to Action.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
     <div>

--- a/docs/components/caption/README.md
+++ b/docs/components/caption/README.md
@@ -117,7 +117,7 @@
 
 Caption aligns to the left alongside the body copy with inset padding. Default caption includes summary and credit.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/caption" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-caption
@@ -131,7 +131,7 @@ Caption aligns to the left alongside the body copy with inset padding. Default c
 
 Summary has same CSS styles as the default; however, only the summary element is displayed.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/caption" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-caption
@@ -145,7 +145,7 @@ Summary has same CSS styles as the default; however, only the summary element is
 
 Credit has same CSS styles as the default; however, only the credit element is displayed.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/caption" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-caption
@@ -159,7 +159,7 @@ Credit has same CSS styles as the default; however, only the credit element is d
 
 The captions component is text-only; however, it is meant to be displayed in the context of a media object.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/caption" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, { components: 'CdrCaption, CdrImg' })" >
+<cdr-doc-example-code-pair repository-href="/src/components/caption" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, { components: 'CdrCaption, CdrImg' })" >
 
 ```html
 <figure>

--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -189,7 +189,7 @@
 
 Default and standard spacing for checkboxes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" :sandbox-data="$page.frontmatter.sandboxData" :model="{ex1: true, ex2: false, ex3: false}" >
+<cdr-doc-example-code-pair repository-href="/src/components/checkbox" :sandbox-data="$page.frontmatter.sandboxData" :model="{ex1: true, ex2: false, ex3: false}" >
 
 ```html
 <div>
@@ -205,7 +205,7 @@ Default and standard spacing for checkboxes.
 
 Compact spacing for checkboxes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" :sandbox-data="$page.frontmatter.sandboxData" :model="{ex1: true, ex2: false, ex3: false}">
+<cdr-doc-example-code-pair repository-href="/src/components/checkbox" :sandbox-data="$page.frontmatter.sandboxData" :model="{ex1: true, ex2: false, ex3: false}">
 
 ```html
 <div>
@@ -221,7 +221,7 @@ Compact spacing for checkboxes.
 
 Displays status for checkbox group by indicating that some of the sub-selections in a list are selected. Provides user with ability to select or unselect all items in the list’s sub-group.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" :sandbox-data="$page.frontmatter.sandboxData" :model="{ex1: false}">
+<cdr-doc-example-code-pair repository-href="/src/components/checkbox" :sandbox-data="$page.frontmatter.sandboxData" :model="{ex1: false}">
 
 ```html
 <div>
@@ -235,7 +235,7 @@ Displays status for checkbox group by indicating that some of the sub-selections
 
 Custom styles for checkboxes.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/checkbox" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: '.no-box:checked ~ .no-box__content {color: green;}'})" class="custom-checkbox-example" :model="{ex1: true, ex2: false, ex3: false}">
+<cdr-doc-example-code-pair repository-href="/src/components/checkbox" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: '.no-box:checked ~ .no-box__content {color: green;}'})" class="custom-checkbox-example" :model="{ex1: true, ex2: false, ex3: false}">
 
 ```html
 <div>

--- a/docs/components/cta/README.md
+++ b/docs/components/cta/README.md
@@ -160,7 +160,7 @@
 
 Use dark Call to Action over a light background image or color to provide proper contrast. This is the default Call to Action style.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/cta" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/cta" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-cta

--- a/docs/components/data-tables/README.md
+++ b/docs/components/data-tables/README.md
@@ -220,7 +220,7 @@
 
 Basic layout with a column of row headers.  Rows alternate background colors.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" :model="{rowHeaders: $page.frontmatter.exampleTableData.rowHeaders, rowData: $page.frontmatter.exampleTableData.rowData, keyOrder: ['xs', 's', 'm', 'l', 'xl', 'xxl', 'xxxl']}">
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" :model="{rowHeaders: $page.frontmatter.exampleTableData.rowHeaders, rowData: $page.frontmatter.exampleTableData.rowData, keyOrder: ['xs', 's', 'm', 'l', 'xl', 'xxl', 'xxxl']}">
 
 
 ```html
@@ -238,7 +238,7 @@ Basic layout with a column of row headers.  Rows alternate background colors.
 
 Layout for making comparisons such as between size/sleeve length. Column headers and row headers are displayed. When columns scroll, row header column is locked in place.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" :model="{colHeaders: $page.frontmatter.exampleTableData.colHeaders, rowHeaders: $page.frontmatter.exampleTableData.rowHeaders, rowData: $page.frontmatter.exampleTableData.rowData, keyOrder: ['xs', 's', 'm', 'l', 'xl', 'xxl', 'xxxl']}">
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" :model="{colHeaders: $page.frontmatter.exampleTableData.colHeaders, rowHeaders: $page.frontmatter.exampleTableData.rowHeaders, rowData: $page.frontmatter.exampleTableData.rowData, keyOrder: ['xs', 's', 'm', 'l', 'xl', 'xxl', 'xxxl']}">
 
 ```html
   <cdr-data-table
@@ -256,7 +256,7 @@ Layout for making comparisons such as between size/sleeve length. Column headers
 
 Layout with reduced spacing within each cell. All cells are borderless. Defines a column of row headers.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-data-table modifier="compact borderless" id="manual-example">
@@ -347,7 +347,7 @@ Data cells:
   - Copy should be short and concise
   - Use sentence case for cell data
   - Text, numerical data, links, buttons, or icons are acceptable
-  
+
 ## Anatomy
 
 Default styles for tables:

--- a/docs/components/grid/README.md
+++ b/docs/components/grid/README.md
@@ -171,7 +171,7 @@
 
 Use rows and columns to lay out content by specifying equal-widths for all columns
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -224,7 +224,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Left
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -246,7 +246,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Center
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -268,7 +268,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Right
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -290,7 +290,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Around
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -312,7 +312,7 @@ Define x-axis alignment and distribute space for all columns per row. Containers
 
 ### Between
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -338,7 +338,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Top
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -360,7 +360,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Bottom
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -382,7 +382,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Middle
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -404,7 +404,7 @@ Define y-axis alignment per row and distribute space across all columns per row.
 
 ### Stretch
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -430,7 +430,7 @@ Defines gutter size for all columns on a row and maintains gutter size by breakp
 
 ### Default
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -461,7 +461,7 @@ Defines gutter size for all columns on a row and maintains gutter size by breakp
 
 ### xxs
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -493,7 +493,7 @@ Defines gutter size for all columns on a row and maintains gutter size by breakp
 ### None
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -528,7 +528,7 @@ Defines direction for items in a container for all columns of a row. This applie
 
 ### Default
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -559,7 +559,7 @@ Defines direction for items in a container for all columns of a row. This applie
 
 ### Vertical
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -594,7 +594,7 @@ Wrapping columns is the default; however, it is possible to disable or enable co
 
 ### Wrap (Default)
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -622,7 +622,7 @@ Wrapping columns is the default; however, it is possible to disable or enable co
 
 ### Nowrap (Scroll)
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -654,7 +654,7 @@ Controls column width by overriding columns value for a specific column or colum
 
 ### 12 Cols
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -703,7 +703,7 @@ Controls column width by overriding columns value for a specific column or colum
 
 ### Span 2
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -749,7 +749,7 @@ Controls column width by overriding columns value for a specific column or colum
 
 ### Span 4
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -793,7 +793,7 @@ Adds empty space (or columns) to left or right of a column, either to the left (
 
 ### Offset Left
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -824,7 +824,7 @@ Adds empty space (or columns) to left or right of a column, either to the left (
 
 ### Offset Right
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -857,7 +857,7 @@ Adds empty space (or columns) to left or right of a column, either to the left (
 
 Overrides row-level alignment for a column. This can be applied to an individual column.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" >
 
 ```html
 <div class="grid-example-wrap">
@@ -889,7 +889,7 @@ Defines nested columns (also known as `isRow`).
 
 ### Simple
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">
@@ -916,7 +916,7 @@ Defines nested columns (also known as `isRow`).
 
 ### Complex
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/grid" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <div class="grid-example-wrap">

--- a/docs/components/headings/README.md
+++ b/docs/components/headings/README.md
@@ -80,7 +80,7 @@
 Use for responsive display heading.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-text
@@ -97,7 +97,7 @@ Use for responsive display heading.
 Use for non-responsive display heading that maintains font size across all viewport sizes.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="display-static">
@@ -112,7 +112,7 @@ Use for non-responsive display heading that maintains font size across all viewp
 Use for a responsive large heading.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="heading-large">
@@ -127,7 +127,7 @@ Use for a responsive large heading.
 Use for non-responsive large heading that maintains font size across all viewport sizes.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="heading-large-static">
@@ -142,7 +142,7 @@ Use for non-responsive large heading that maintains font size across all viewpor
 Use for a responsive medium heading.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="heading-medium">
@@ -157,7 +157,7 @@ Use for a responsive medium heading.
 Use for non-responsive medium heading that maintains font size across all viewport sizes.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="heading-medium-static">
@@ -172,7 +172,7 @@ Use for non-responsive medium heading that maintains font size across all viewpo
 Use for a responsive small heading.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="heading-small">
@@ -187,7 +187,7 @@ Use for a responsive small heading.
 Use for non-responsive small heading that maintains font size across all viewport sizes.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="heading-small-static">
@@ -202,7 +202,7 @@ Use for non-responsive small heading that maintains font size across all viewpor
 Use for subheadings that are positioned beneath small headings.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
   <cdr-text modifier="subheading">

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -139,7 +139,7 @@ A collection of SVG icon files composed into a single file. This method provides
 
 See the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) to generate a sprite sheet for your project. You will need to ensure that your sprite contains all the Cedar icons used in your application, including those used in shared components. The generated sprite sheet should be rendered inline at the root of your HTML. You should avoid rendering the sprite sheet in JavaScript/Vue, as that will cause it to be included twice (once in the server rendered HTML, and once in the client side bundle).
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/icon" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrIcon'})" :load-sprite="true">
+<cdr-doc-example-code-pair repository-href="/src/components/icon" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrIcon'})" :load-sprite="true">
 
 ```html
   <cdr-icon use="#arrow-up" />
@@ -152,7 +152,7 @@ See the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) to generate a
 
 Create a new SVG icon using any valid internal SVG markup. This method creates an outer SVG wrapper for accessibility and styles. This is not recommended if using a large number of icons.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/icon" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/icon" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-icon>

--- a/docs/components/image/README.md
+++ b/docs/components/image/README.md
@@ -120,7 +120,7 @@
 Use for images with no responsive qualities.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 
@@ -137,7 +137,7 @@ Use for images with no responsive qualities.
 Apply rules to an image using ratio and crop properties. The below example is cropped using top alignment with the aspect ratio set as 9-16
 
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <cdr-img
@@ -154,7 +154,7 @@ Apply rules to an image using ratio and crop properties. The below example is cr
 Use the cover property to resize the background image to fill the entire container.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <cdr-img
@@ -177,7 +177,7 @@ Apply a radius to an image.
 The below example is cropped using center alignment with the aspect ratio set as square and the radius set as rounded.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-img
@@ -195,7 +195,7 @@ The below example is cropped using center alignment with the aspect ratio set as
 The below example is cropped using center alignment with the aspect ratio set as square and the radius set as circle.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/image" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-img

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -106,7 +106,7 @@
 
 Display within body copy for articles, hub cards, footer, or recommendations.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/link" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
 <cdr-text>

--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -98,7 +98,6 @@ Collect items to be displayed in a list when items are not marked with bullets. 
 
 <cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight= false >
 
-<template slot="Default">
 
 ```html
   <cdr-list>
@@ -111,23 +110,6 @@ Collect items to be displayed in a list when items are not marked with bullets. 
     <li>Default list item 3</li>
   </cdr-list>
 ```
-</template>
-
-<template slot="compact">
-
-```html
-  <cdr-list modifier="compact">
-    <li>Compact list item 1</li>
-    <li>Compact list item 2
-      <cdr-list>
-        <li>Compact list item</li>
-      </cdr-list>
-    </li>
-    <li>Compact list item 3</li>
-  </cdr-list>
-```
-
-</template>
 
 </cdr-doc-example-code-pair>
 
@@ -136,7 +118,6 @@ Collect items to be displayed in a list when items are not marked with bullets. 
 Collect related items that don’t need to be in a specific order or sequence. List items are typically marked with bullets.
 
 <cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
-<template slot="Default">
 
 ```html
   <cdr-list modifier="unordered">
@@ -149,24 +130,6 @@ Collect related items that don’t need to be in a specific order or sequence. L
     <li>Default list item 3</li>
   </cdr-list>
 ```
-</template>
-
-<template slot="compact">
-
-```html
-  <cdr-list modifier="unordered compact">
-    <li>Compact list item 1</li>
-    <li>Compact list item 2
-      <cdr-list>
-        <li>Compact list item</li>
-      </cdr-list>
-    </li>
-    <li>Compact list item 3</li>
-  </cdr-list>
-```
-
-</template>
-
 
 </cdr-doc-example-code-pair>
 
@@ -176,7 +139,6 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
 
 <cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
-<template slot="Default">
 
 ```html
   <cdr-list tag="ol" modifier="ordered">
@@ -189,23 +151,6 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
     <li>Default list item 3</li>
   </cdr-list>
 ```
-</template>
-
-<template slot="compact">
-
-```html
-  <cdr-list tag="ol" modifier="ordered compact">
-    <li>Compact list item 1</li>
-    <li>Compact list item 2
-      <cdr-list>
-        <li>Compact list item</li>
-      </cdr-list>
-    </li>
-    <li>Compact list item 3</li>
-  </cdr-list>
-```
-
-</template>
 
 </cdr-doc-example-code-pair>
 

--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -96,7 +96,7 @@
 
 Collect items to be displayed in a list when items are not marked with bullets.  This is the default and is also known as unordered and undecorated “bare” list.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight= false >
+<cdr-doc-example-code-pair repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight= false >
 
 
 ```html
@@ -117,7 +117,7 @@ Collect items to be displayed in a list when items are not marked with bullets. 
 
 Collect related items that don’t need to be in a specific order or sequence. List items are typically marked with bullets.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-list modifier="unordered">
@@ -137,7 +137,7 @@ Collect related items that don’t need to be in a specific order or sequence. L
 
 Collect related items with numeric order or sequence. Numbering starts at 1 with the first list item and increases by increments of 1 for each successive ordered list item.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 
 ```html
@@ -158,7 +158,7 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
 
 Display items horizontally with no divider.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 <template slot="Default">
 
@@ -189,7 +189,7 @@ Display items horizontally with no divider.
 
 Display items horizontally, separated by a bullet character.
 
-<cdr-doc-example-code-pair :background-toggle="false" :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 <template slot="Default">
 

--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -96,7 +96,7 @@
 
 Collect items to be displayed in a list when items are not marked with bullets.  This is the default and is also known as unordered and undecorated “bare” list.
 
-<cdr-doc-example-code-pair repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight= false >
+<cdr-doc-example-code-pair repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" >
 
 
 ```html
@@ -117,7 +117,7 @@ Collect items to be displayed in a list when items are not marked with bullets. 
 
 Collect related items that don’t need to be in a specific order or sequence. List items are typically marked with bullets.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-list modifier="unordered">
@@ -137,7 +137,7 @@ Collect related items that don’t need to be in a specific order or sequence. L
 
 Collect related items with numeric order or sequence. Numbering starts at 1 with the first list item and increases by increments of 1 for each successive ordered list item.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 
 ```html
@@ -154,11 +154,32 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
 
 </cdr-doc-example-code-pair>
 
+## Compact
+
+Compact modifier can be added to any cdr-list in order to reduce the margin between list items
+
+<cdr-doc-example-code-pair repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" >
+
+
+```html
+  <cdr-list modifier="compact unordered">
+    <li>Compact unordered list item 1</li>
+    <li>Compact unordered list item 2
+      <cdr-list>
+        <li>Compact unordered list item</li>
+      </cdr-list>
+    </li>
+    <li>Compact unordered list item 3</li>
+  </cdr-list>
+```
+
+</cdr-doc-example-code-pair>
+
 ## Inline
 
 Display items horizontally with no divider.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 <template slot="Default">
 
@@ -189,7 +210,7 @@ Display items horizontally with no divider.
 
 Display items horizontally, separated by a bullet character.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair :codeMaxHeight="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
 <template slot="Default">
 

--- a/docs/components/paragraphs/README.md
+++ b/docs/components/paragraphs/README.md
@@ -108,7 +108,7 @@
 Used as default font style for all text information. Also known as body-default in UI ToolKit.
 
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData" >
+<cdr-doc-example-code-pair repository-href="/src/components/text" :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
   <cdr-text>Pack everything you need with this handy checklist! We include the 10 essentials and more for comfort in the backcountry.</cdr-text>

--- a/docs/components/pull-quote/README.md
+++ b/docs/components/pull-quote/README.md
@@ -141,7 +141,7 @@
 
 Default pull quote can be used with the following HTML tags: `<p>`, `<div>`, `<aside>`. For XS breakpoint, a border is below pull quote and font size is smaller.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/quote" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/quote" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
 <div>

--- a/docs/components/rating/README.md
+++ b/docs/components/rating/README.md
@@ -122,7 +122,7 @@
 
 Shows review rating with up to 5 stars highlighted. If rating is zero, star icons are displayed using the grey outline star icon.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
 <div>
@@ -137,7 +137,7 @@ Shows review rating with up to 5 stars highlighted. If rating is zero, star icon
 
 Creates a link to the corresponding review content if on the same page.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
 <div>
@@ -156,7 +156,7 @@ Creates a link to the corresponding review content if on the same page.
 
 Removes the word "Reviews" from the label for limited space layout.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
 <div>
@@ -171,7 +171,7 @@ Removes the word "Reviews" from the label for limited space layout.
 
 Change size for the star icon and text. Default size is medium.
 
-<cdr-doc-example-code-pair :background-toggle="false" repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
+<cdr-doc-example-code-pair repository-href="/src/components/rating" :sandbox-data="$page.frontmatter.sandboxData">
 
 ```html
 <div>

--- a/docs/layout/responsive/README.md
+++ b/docs/layout/responsive/README.md
@@ -38,7 +38,7 @@ The Cedar container allows flexible content width, up to a max width of 1232px. 
 
 To explore how the containers work, check out this Cedar sandbox:
 
-<cdr-doc-example-code-pair :background-toggle="false" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: 'body { background-color: rgba(130, 234, 255, 0.35);} .content {background-color: #fff;} .cdr-container, .cdr-container-fluid { background-color: lightcoral; color: purple;}'})" >
+<cdr-doc-example-code-pair :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: 'body { background-color: rgba(130, 234, 255, 0.35);} .content {background-color: #fff;} .cdr-container, .cdr-container-fluid { background-color: lightcoral; color: purple;}'})" >
 
 ```vue
   <div>

--- a/docs/proving-grounds/example-code-pair/README.md
+++ b/docs/proving-grounds/example-code-pair/README.md
@@ -19,7 +19,7 @@ pageClass: cdr-doc-proving-ground
 
 ## Hide Background Toggle, Code Toggle, add repository and sandbox links
 
-<cdr-doc-example-code-pair :background-toggle="false" :code-toggle="false" repository-href="http://github.com/rei" sandbox-href="http://codesandbox.io">
+<cdr-doc-example-code-pair :code-toggle="false" repository-href="http://github.com/rei" sandbox-href="http://codesandbox.io">
 
 ```html
   <div>

--- a/docs/proving-grounds/html-example-list/README.md
+++ b/docs/proving-grounds/html-example-list/README.md
@@ -28,7 +28,7 @@ pageClass: cdr-doc-proving-ground
 </cdr-doc-html-example-list>
 
 ## No Background Toggle
-<cdr-doc-html-example-list :background-toggle="false">
+<cdr-doc-html-example-list >
 ```html
   <cdr-list
     modifier="unordered"
@@ -52,7 +52,7 @@ pageClass: cdr-doc-proving-ground
 </cdr-doc-html-example-list>
 
 ## No Background Toggle, background color set to dark
-<cdr-doc-html-example-list :background-toggle="false" background-color="dark">
+<cdr-doc-html-example-list background-color="dark">
 ```html
   <cdr-button>Testing</cdr-button>
 ```
@@ -125,7 +125,7 @@ pageClass: cdr-doc-proving-ground
 
 ## Multiple Examples, hide background toggles and manually set individual item backgrounds
 
-<cdr-doc-html-example-list :background-colors="{'Default':'dark', 'Focused':'dark'}" :background-toggle="false">
+<cdr-doc-html-example-list :background-colors="{'Default':'dark', 'Focused':'dark'}" >
   <template slot="Default">
 
 ```html


### PR DESCRIPTION
- makes backgroundToggle default to false (it doesn't actually trigger on-dark so it doesn't do a whole lot...link and button seem to be the only components with `on-dark` props)
- simplifies cdrList examples, adds a separate one for compact
