### PR TITLE
additional metadata in header

### DIFF
--- a/docs/components/grid/README.md
+++ b/docs/components/grid/README.md
@@ -3,7 +3,7 @@
   "title": "Grid",
   "layout_type": "LayoutComponent",
   "summary": "A responsive, mobile first, fluid system that appropriately scales 12 columns as the device or viewport size increases",
-  "title_metadata": "Layout, CdrGrid",
+  "title_metadata": "Layout, CdrGrid, CdrRow, CdrCol",
   "consistent": [
     {
       "type": "do",


### PR DESCRIPTION
got user feedback that they were confused looking for 'CdrGrid', when really they needed 'CdrRow' and 'CdrCol' - making this a little more visibile