### PR TITLE
missing image/code example

### DIFF
--- a/docs/layout/responsive/README.md
+++ b/docs/layout/responsive/README.md
@@ -36,7 +36,7 @@ The Cedar container allows flexible content width, up to a max width of 1232px. 
 
 <cdr-img :src="$withBase('/layout/StandardvFluid.gif')" alt="Standard vs. Fluid container " />
 
-To explore how the containers work, check out this co sandbox:
+To explore how the containers work, check out this code sandbox:
 
 <cdr-doc-example-code-pair :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: 'body { background-color: rgba(130, 234, 255, 0.35);} .content {background-color: #fff;} .cdr-container, .cdr-container-fluid { background-color: lightcoral; color: purple;}'})" >
 

--- a/docs/layout/responsive/README.md
+++ b/docs/layout/responsive/README.md
@@ -113,7 +113,7 @@ For example, a selector may target a small variant within the small breakpoint r
   }
 }
 ```
-* Exploding the name `--sm-mq-only` would read “small-media-query-only
+Exploding the name `sm-mq-only` would read “small-media-query-only
 
 Using the range ensures that the specified key:value pairs only applies to the `.cdr-example--small@sm` class name when it is displayed within the range of 768px-991px.
 
@@ -137,11 +137,16 @@ When accepted, a breakpoint variant property will append the `@(xs, sm, md, lg)`
 
 For example, to display the `cdr-button-small` variant at the small breakpoint:
 
-Note that the Cedar components will always use the range breakpoints. If you intend a component to continue to use the breakpoint variant within a different breakpoint range, you will also need to account for it within the same property definition.
+```vue
+<cdr-button size="small@sm">
+  A primary button
+</cdr-button>
 ```
-<cdr-button
-  size="small@xs small@sm small@md"
->
+
+Note that the Cedar components will always use the range breakpoints. If you intend a component to continue to use the breakpoint variant within a different breakpoint range, you will also need to account for it within the same property definition.
+
+```vue
+<cdr-button size="small@xs small@sm small@md">
   A primary button
 </cdr-button>
 ```


### PR DESCRIPTION
- fixed type 
- the bullet on line 116 (* Exploding the name `--sm-mq-only` would read “small-media-query-only) looks like it's intended to be a caption of the table above it, possible to adjust the styling of it? Confusing to read as-is
- there's a code example missing in the last section on components - I've left a comment in the google doc for reference: https://docs.google.com/document/d/16sP_GiI82XTSO3vghAFOyWSLxJs20wucRSarFHEPHIc/edit

> these second 2 bullets were referenced in the last commit I made, but I don't see that it's been updated on the staging site