### PR TITLE
update to cedar 3.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -846,9 +846,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.6.2.tgz",
-      "integrity": "sha512-FX1ddj2gf7psgslvkkKeyxftnslUFDY9OHGnp+wJ+4JIKSEABB1fKVZiE7/2n+C9RVTPfPwpOqGmFf5TGvg0Bw==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.6.3.tgz",
+      "integrity": "sha512-933SXHQr7apa95F+3IqkBne8mqOnu1kDh6dnSddC07aW/R51WsOVD7MSczJ6DRpq/L8KLll7TFDxmt30pft44w==",
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
@@ -927,9 +927,9 @@
       "dev": true
     },
     "@rei/cedar": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-3.0.0.tgz",
-      "integrity": "sha512-4hVGphIms53tZIoiStYS3eKJLmal7u4H95cGZ/kCuz/Krp+B/O6xxGCpAH3uViJfRkf9X9e06bGmiAREnulpEg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-3.0.3.tgz",
+      "integrity": "sha512-CyBx3TGTNkySmsb133KwZzSFutkiQI5a05IDxt3SyHJZRJVHphot0o35It8W2L6yMjSsQMnM20cs4Xx274Hy4Q==",
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@babel/runtime-corejs3": "^7.5.5",
@@ -3556,9 +3556,9 @@
       "dev": true
     },
     "core-js-pure": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
-      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.3.2.tgz",
+      "integrity": "sha512-sw695hB0UxFXrSkUthEby5tMdjOYN3hVC8IGQePF1m3JYb9e/KjT0TOFWzaSzlKwGNglKCgLYUjiJ7uZvactiw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -5426,7 +5426,7 @@
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -5623,14 +5623,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -5642,7 +5642,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -5672,14 +5672,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -5835,7 +5835,7 @@
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
@@ -6284,7 +6284,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vuepress": "^1.0.3"
   },
   "dependencies": {
-    "@rei/cedar": "^3.0.0",
+    "@rei/cedar": "^3.0.3",
     "scrollmonitor": "^1.2.4",
     "smoothscroll-polyfill": "^0.4.4",
     "stickyfilljs": "^2.0.5"


### PR DESCRIPTION
Everything looks good/fixed on the doc site/codesandbox.

Here's a blurb for the slack channels:

```
We just published a patch version (3.0.3) of Cedar that fixes a few issues introduced in our fall release.
- Icon: Size and space props were not working in our single icon components
- Accordion: Caret icon was rendering at the wrong size when passed `compact`
- Rating: Review count of 0 was being shown when the `count` prop is not passed
- Select: Caret icon was not reflecting disabled state 
```
