### PR TITLE
fix getting started CSS import example

### DIFF
--- a/docs/getting-started/as-a-developer/README.md
+++ b/docs/getting-started/as-a-developer/README.md
@@ -112,25 +112,22 @@ import '@rei/cedar/dist/cdr-fonts.css';
 import '@rei/cedar/dist/cedar.css';
 ```
 
-##### PostCSS
-Cedar packages include the [unofficial style field](https://jaketrent.com/post/package-json-style-attribute/) supported by `postcss-import`.
-
-_cedar.postcss_
-```css
-import '@rei/cedar/dist/cdr-fonts.css';
-import '@rei/cedar’;
-```
-
 ##### SCSS
 You can also import CSS from the node_modules folder such as SCSS or another pre-processor.
 
 _cedar.scss_
 ```js
-import '~@rei/cedar/dist/cdr-fonts.css';
-import '~@rei/cedar/dist/cedar.css';
+@import '~@rei/cedar/dist/cdr-fonts.css';
+@import '~@rei/cedar/dist/cedar.css';
 ```
+##### PostCSS
+Cedar packages include the [unofficial style field](https://jaketrent.com/post/package-json-style-attribute/) supported by `postcss-import`.
 
-**Note**: Code snippets provided throughout this documentation will demonstrate the `webpack` and `css-loader` method.
+_cedar.postcss_
+```pcss
+import '@rei/cedar/dist/cdr-fonts.css';
+import '@rei/cedar’;
+```
 
 <hr/>
 

--- a/docs/getting-started/as-a-developer/README.md
+++ b/docs/getting-started/as-a-developer/README.md
@@ -116,7 +116,7 @@ import '@rei/cedar/dist/cedar.css';
 You can also import CSS from the node_modules folder such as SCSS or another pre-processor.
 
 _cedar.scss_
-```js
+```scss
 @import '~@rei/cedar/dist/cdr-fonts.css';
 @import '~@rei/cedar/dist/cedar.css';
 ```


### PR DESCRIPTION
found this while doing user support, the example we give for importing cedar into SCSS doesn't actually work with FEBS (see climbers for a correct example `climbers-site/src/main/style/pages/common/cdr-base.scss`)

I also moved the PCSS example lower as the webpack/scss examples are more likely what our users want, and postcss-import isn't in febs by default.
