### PR TITLE
Fix radio hide figure example

### DIFF
--- a/docs/components/radio/README.md
+++ b/docs/components/radio/README.md
@@ -350,9 +350,9 @@ Use the `hide-figure` modifier to hide the radio button itself, which leaves tex
 ```vue
 <template>
   <cdr-radio
+    name="example"
+    custom-value="model1"
     v-model="model"
-    name="model"
-    value="model"
     modifier="hide-figure"
     input-class="no-box"
     content-class="no-box__content"


### PR DESCRIPTION
As called out in Cedar User Support Channel as being incorrect, this PR fixes the incorrect example on the Radio Button hide figure example under the API tab.  

The Cedar User Support call out is here:  https://rei.slack.com/archives/CA58YCGN4/p1572999966087500