### PR TITLE
Code only examples

### DIFF
--- a/docs/.vuepress/components/cdr-doc-code-snippet.vue
+++ b/docs/.vuepress/components/cdr-doc-code-snippet.vue
@@ -101,6 +101,7 @@ export default {
       copyNotSupported: false,
       codeHidden: false,
       hideCodeToggleText: 'Hide code',
+      sandboxCode: {},
       repositoryRoot: 'https://github.com/rei/rei-cedar/tree/19.02.1'
     }
   },
@@ -108,9 +109,14 @@ export default {
     this.codeHidden = this.hideCode;
     this.setCodeToggleText();
   },
+  mounted() {
+    this.sandboxCode = {
+      code: this.$refs.source.querySelector('code').textContent,
+    }
+  },
   computed: {
     sandboxHrefComputed() {
-      return this.sandboxHref || buildSandbox(this.sandboxData, this.model);
+      return this.sandboxHref || buildSandbox(Object.assign({}, this.sandboxCode, this.sandboxData), this.model);
     }
   },
   methods: {

--- a/docs/.vuepress/theme/styles/examples.scss
+++ b/docs/.vuepress/theme/styles/examples.scss
@@ -1,3 +1,4 @@
+// Update frontmatter sandboxData styleTag in components/grid if changing this.
 .grid-example-wrap {
   width: 100%;
 

--- a/docs/components/grid/README.md
+++ b/docs/components/grid/README.md
@@ -47,7 +47,45 @@
     },
   ],
   "sandboxData": {
-    "components": "CdrRow, CdrCol"
+    "components": "CdrRow, CdrCol",
+    "styleTag": ".grid-example-wrap {
+      width: 100%;
+
+      [class^=\"cdr-row\"] {
+        position: relative;
+        
+        &::before {
+          content: '';
+          position: absolute;
+          top: 1.6rem;
+          left: 1.6rem;
+          height: 100%;
+          width: 100%;
+          background-color: rgba(130, 234, 255, 0.1);
+          
+          @media (max-width: $cdr-breakpoint-md) {
+            top: 0.8rem;
+            left: 0.8rem;
+          }
+        }
+      }
+
+      [class*=\"cdr-row--gutter-xxs\"]::before {
+        top: .2rem;
+        left: .2rem;
+      }
+
+      [class*=\"cdr-row--gutter-none\"]::before {
+        top: 0;
+        left: 0;
+      }
+
+      [class^=\"cdr-col__content\"] {
+        background-color: rgba(130, 234, 255, 0.35);
+        color: rgba(60, 120, 174, 1.0);
+        text-align: center;
+      }
+    }",
   },
   "versions": [
     {

--- a/docs/layout/responsive/README.md
+++ b/docs/layout/responsive/README.md
@@ -38,21 +38,21 @@ The Cedar container allows flexible content width, up to a max width of 1232px. 
 
 To explore how the containers work, check out this code sandbox:
 
-<cdr-doc-example-code-pair :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: 'body { background-color: rgba(130, 234, 255, 0.35);} .content {background-color: #fff;} .cdr-container, .cdr-container-fluid { background-color: lightcoral; color: purple;}'})" >
+<cdr-doc-code-snippet :max-height="false" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: 'body { background-color: rgba(130, 234, 255, 0.35);} .content {background-color: #fff;} .cdr-container, .cdr-container-fluid { background-color: lightcoral; color: purple;}'})" >
 
 ```vue
   <div>
     <div class="cdr-container">
       <div class="content">A cdr-container class</div>
-
     </div>
+
     <div class="cdr-container-fluid">
       <div class="content">A cdr-container-fluid class</div>
     </div>
   </div>
 
 ```
-</cdr-doc-example-code-pair>
+</cdr-doc-code-snippet>
 
 ## Display Breakpoints
 Cedar provides support for four layout screen widths: extra small, small, medium, and large.

--- a/utils/buildSandbox.js
+++ b/utils/buildSandbox.js
@@ -32,6 +32,7 @@ export default function makeMeASandbox(data, model) {
             // TODO: can we grab the preceding text to use for description?
           "description": "https://rei.github.io/rei-cedar-docs/",
           "dependencies": {
+            "@rei/cdr-tokens": packageJson.devDependencies['@rei/cdr-tokens'],
             "@rei/cedar": packageJson.dependencies['@rei/cedar'],
             "vue": "^2.5.22"
           }
@@ -68,6 +69,7 @@ function buildIndexHtml(title) {
 }
 
 function buildContent(data, model, fontImport) {
+  console.log(data);
   return `
 <template>
   <div style="margin: 32px;">
@@ -80,7 +82,8 @@ function buildContent(data, model, fontImport) {
   ${buildScriptTag(data, model)}
 </script>
 
-<style>
+<style lang="scss">
+  @import "~@rei/cdr-tokens/dist/scss/cdr-tokens.scss";
   ${data.styleTag || ''}
 </style>`;
 }

--- a/utils/buildSandbox.js
+++ b/utils/buildSandbox.js
@@ -69,7 +69,6 @@ function buildIndexHtml(title) {
 }
 
 function buildContent(data, model, fontImport) {
-  console.log(data);
   return `
 <template>
   <div style="margin: 32px;">


### PR DESCRIPTION
- Change container example to code only
- Extract code from slot in `cdr-doc-code-snippet` (only happened in `cdr-doc-example-code-pair` before)
- Add example styles to sandbox for grid
- Sandbox styles are scss
- auto import tokens into sandbox examples