### PR TITLE
clarify icon usage

### DIFF
--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -225,16 +225,15 @@ Use secondary buttons for all actions that do not move the user to the next step
 
 Pair an icon with text to improve recognition about an object or action.
 
-<cdr-doc-example-code-pair repository-href="/src/components/button" :load-sprite="true" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, CdrIcon'})" >
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, IconPlayStroke'})" >
 
 ```html
   <div>
     <cdr-button
       modifier="secondary"
     >
-      <cdr-icon
+      <IconPlayStroke
         slot="icon"
-        use="#play-stroke"
         class="cdr-button__icon"
         inherit-color
       />
@@ -244,9 +243,8 @@ Pair an icon with text to improve recognition about an object or action.
       modifier="secondary"
       disabled
     >
-      <cdr-icon
+      <IconPlayStroke
         slot="icon"
-        use="#play-stroke"
         class="cdr-button__icon"
         inherit-color
       />
@@ -261,7 +259,7 @@ Pair an icon with text to improve recognition about an object or action.
 
 Use to visually communicate an object or action in limited space. Include alternative text to describe what button does.
 
-<cdr-doc-example-code-pair repository-href="/src/components/button" :load-sprite="true" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, CdrIcon'})" >
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, IconQuestionFill'})" >
 
 ```html
   <div>
@@ -269,10 +267,9 @@ Use to visually communicate an object or action in limited space. Include altern
       :icon-only="true"
       aria-label="More information about icon"
     >
-      <cdr-icon
+      <IconQuestionFill
         slot="icon"
         class="cdr-button__icon"
-        use="#question-fill"
         inherit-color
       />
     </cdr-button>
@@ -505,27 +502,26 @@ export default {
 
 To scale Cedar icons appropriately, include the `cdr-button__icon` class with any icon component. The `size` prop scales both the icon and button.
 
-In the below example, a "Download" button is rendered as a button with icon and text using `cdr-icon` and the icon sprite.
+In the below example, a "Download" button is rendered as a button with icon and text using and inline Cedar icon component.
 
 ```vue{5}
 <template>
   <cdr-button>
-    <cdr-icon
+    <IconDownload
       slot="icon"
       class="cdr-button__icon"
-      use="#download"
     />
     Download
   </cdr-button>
 </template>
 
 <script>
-import { CdrButton, CdrIcon } from '@rei/cedar';
+import { CdrButton, IconDownload } from '@rei/cedar';
 export default {
   ...
   components: {
      CdrButton,
-     CdrIcon,  
+     IconDownload,  
   }
 }
 </script>

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -133,9 +133,22 @@
 <template slot="Overview">
 <cdr-doc-table-of-contents-shell>
 
+## Inline Icon Components
+
+The inline icon components are the recommended method for using Cedar icons in a Vue application. Cedar exports a component version of every SVG Icon in the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/). These components are named using PascalCase, for example `account-profile` becomes `IconAccountProfile` or `camping` becomes `IconCamping`.
+
+<cdr-doc-example-code-pair repository-href="/src/components/icon" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'IconAccountProfile, IconCamera'})">
+
+```html
+  <IconAccountProfile />
+  <IconCamera />
+```
+
+</cdr-doc-example-code-pair>
+
 ## SVG Sprite
 
-A collection of SVG icon files composed into a single file. This method provides a single server download request and caches icons for display. This is the most efficient way of displaying large numbers of icons.
+A collection of SVG icon files composed into a single file. This method provides a single server download request and caches icons for display. This is the most efficient way of displaying large numbers of icons, but has an added maintenance cost in that every icon used in the application must be manually added to it's sprite sheet. We recommend using the [inline icon components](#inline-icon-components), and optimizing to use a sprite only if it would provide a measurable performance benefit.
 
 See the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) to generate a sprite sheet for your project. You will need to ensure that your sprite contains all the Cedar icons used in your application, including those used in shared components. The generated sprite sheet should be rendered inline at the root of your HTML. You should avoid rendering the sprite sheet in JavaScript/Vue, as that will cause it to be included twice (once in the server rendered HTML, and once in the client side bundle).
 
@@ -149,20 +162,6 @@ See the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) to generate a
 </cdr-doc-example-code-pair>
 
 
-## Inline Icon Components
-
-While using an icon sprite is the most optimal way of loading SVGs there may be use cases where you need to inline SVG content directly in your markup. For example, if you are building a component that may be rendered across multiple pages and you cannot guarantee that your icon sprite will always be present.
-
-For these cases, Cedar exports a component version of every SVG Icon in the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/). These components are named using capitalized camel casing, for example `account-profile` becomes `IconAccountProfile` or `camping` becomes `IconCamping`.
-
-<cdr-doc-example-code-pair repository-href="/src/components/icon" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'IconAccountProfile, IconCamera'})">
-
-```html
-  <IconAccountProfile />
-  <IconCamera />
-```
-
-</cdr-doc-example-code-pair>
 
 ## Non-Cedar SVG
 

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -337,7 +337,7 @@ Input field with link text on right.
 
 Input field with icon above input field on right.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, CdrIcon'})" :load-sprite="true" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconInformationFill'})" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -345,9 +345,8 @@ Input field with icon above input field on right.
   label="Input label"
   placeholder="Placeholder input"
 >
-  <cdr-icon
+  <IconInformationFill
     slot="info"
-    use="#information-fill"
     class="cdr-button__icon"
     inherit-color
   />
@@ -380,7 +379,7 @@ Input field with helper or hint text below input field.
 
 Input field with icon inserted into input field on left. Icon is decorative and not intended for any action.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, CdrIcon'})" :load-sprite="true" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconLocationPinStroke'})" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -388,9 +387,8 @@ Input field with icon inserted into input field on left. Icon is decorative and 
   label="Input label"
   placeholder="Placeholder input"
 >
-  <cdr-icon
+  <IconLocationPinStroke
     slot="pre-icon"
-    use="#location-pin-stroke"
     class="cdr-button__icon"
     inherit-color
   />
@@ -403,7 +401,7 @@ Input field with icon inserted into input field on left. Icon is decorative and 
 
 Input field with icon inserted into input field on right. Icon is decorative and not intended for any action.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, CdrIcon'})" :load-sprite="true" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconCreditCard'})" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
@@ -411,9 +409,8 @@ Input field with icon inserted into input field on right. Icon is decorative and
   label="Input label"
   placeholder="Placeholder input"
 >
-  <cdr-icon
+  <IconCreditCard
     slot="post-icon"
-    use="#credit-card"
     class="cdr-button__icon"
     inherit-color
   />

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -142,16 +142,14 @@ Display independently with a call to action. Some examples are for finding a sto
 
 Display standalone link with icon on left.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" :load-sprite="true" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrLink'})">
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrLink, IconShipping'})">
 
 ```html
   <div>
     <cdr-link tag="button" modifier="standalone">
-      <!-- Using the sprite -->
-      <cdr-icon
-          use="#shipping"
-          inherit-color
-          class="cdr-mr-space-half-x"
+      <IconShipping
+        inherit-color
+        class="cdr-mr-space-half-x"
       />
       This item ships for FREE!
     </cdr-link>
@@ -164,17 +162,15 @@ Display standalone link with icon on left.
 
 Display standalone link with icon on right.
 
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" :load-sprite="true" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrLink'})">
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrLink, IconExternalLink'})">
 
 ```html
   <div>
       <cdr-link modifier="standalone">
         Visit site
-        <!-- Using the sprite -->
-        <cdr-icon
-            use="#external-link"
-            inherit-color
-            class="cdr-ml-space-half-x"/>
+        <IconExternalLink
+          inherit-color
+          class="cdr-ml-space-half-x"/>
       </cdr-link>
   </div>
 ```

--- a/docs/components/pagination/README.md
+++ b/docs/components/pagination/README.md
@@ -187,7 +187,7 @@ click,
 - `content`: the default content for that link
 - `iconClass`: a class to be applied to the prev/next arrow icon in order to match pagination styling
 - `iconPath`: the path to the icon in the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) used for this link
-- `iconComponent`: name of the component used for this link (if not using sprite/`iconPath`)
+- `iconComponent`: name of the component used for this link 
 - `click`: function ran when element is clicked. Required for internal component behavior
 
 <cdr-doc-example-code-pair repository-href="/src/components/accordion" :sandbox-data="$page.frontmatter.sandboxData" :model="{ page: 2, pages: [{page: 1, url: '1'}, {page: 2, url: '2'}, {page: 3, url: '3'}] }">

--- a/docs/icons/resources/README.md
+++ b/docs/icons/resources/README.md
@@ -64,6 +64,16 @@ File name examples:
 `gear-boating-canoe.svg`<br>
 `gear-boating-paddleboard.svg`
 
+### Using Inline Cedar Icons
+
+The `@rei/cedar` component package exports an [inline Vue component](https://rei.github.io/rei-cedar-docs/components/icon/#inline-icon-components) for every icon in the Cedar library. The inline icon components are the easiest way to make use of the Cedar icon library if you are building an application using Vue. These components are prefixed with the word `Icon` and are named using PascalCase, for example: `IconCaretDown`, `IconExperiencesBackpacking`.
+
+### Creating a Cedar Icon Sprite
+
+Icon sprite sheets should be avoided in favor of using the [inline cedar icon components](#using-inline-cedar-icons), as maintaining sprite sheets is difficult and usually has minimal impact on performance. However we do offer a sprite option for teams that needd to optimize their icon usage.
+
+The Cedar Icon Library has an easy to-use [sprite creator](https://rei.github.io/cedar-icons/#/sprite). Alternately, the icon library API also provides [sprite generation](https://github.com/rei/cedar-icons#creating-a-custom-sprite). The sprite can then be referenced using the [CdrIcon component](https://rei.github.io/rei-cedar-docs/components/icon/#svg-sprite)
+
 ## Contribution Process
 
 Cedar welcomes and encourages contributions to the icon library that are consistent with the REI style.
@@ -93,13 +103,6 @@ Icons must be created at 24x24px size format. However, they can be displayed in 
 - md: 24x24px
 - lg: 32x32px
 
-
-### Creating a Cedar Icon Sprite
-
-The Cedar Icon Library has an easy to-use [sprite creator](https://rei.github.io/cedar-icons/#/sprite).
-
-Alternately, the icon library API also provides [sprite generation](https://github.com/rei/cedar-icons#creating-a-custom-sprite).
-
 ### Adding an Icon to the Cedar Icon Library
 
 1. In Abstract, create a new branch of the [CDR - Icon Contribution](https://share.goabstract.com/99335c38-51ee-41c8-8454-38c2a70c4c7f) project.
@@ -107,8 +110,8 @@ Alternately, the icon library API also provides [sprite generation](https://gith
 3. Duplicate the **Template (Right-click > Duplicate Page)** for each new icon or set of icons. (It is ok to leave alternate versions on the page, but please indicate the final version.)
 4. Follow the [Iconography](../../icons/iconography/) guidelines to ensure that your icon follows Cedar’s requirements.
 5. Make a final version of your icon and add it as a page. Each new icon or set should have its own page.
-6. Add a member of the Cedar team as a reviewer. 
-7. Your icon will be merged into the **CDR Icons • vNext** library and released in the next version of Cedar. 
+6. Add a member of the Cedar team as a reviewer.
+7. Your icon will be merged into the **CDR Icons • vNext** library and released in the next version of Cedar.
 
 ### Exporting Icons That Aren’t in the Library
 


### PR DESCRIPTION
CDR-1492

- updates icon component docs and icon resources pages to prioritize inline icons
- updates examples that use icons to use the inline components instead of sprites