### PR TITLE
remove compact example slots from list

### DIFF
--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -139,7 +139,6 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
 
 <cdr-doc-example-code-pair :codeMaxHeight="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
-
 ```html
   <cdr-list tag="ol" modifier="ordered">
     <li>Default list item 1</li>
@@ -159,7 +158,6 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
 Compact modifier can be added to any cdr-list in order to reduce the margin between list items
 
 <cdr-doc-example-code-pair repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" >
-
 
 ```html
   <cdr-list modifier="compact unordered">
@@ -181,8 +179,6 @@ Display items horizontally with no divider.
 
 <cdr-doc-example-code-pair :codeMaxHeight="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
-<template slot="Default">
-
 ```html
   <cdr-list modifier="inline">
     <li>Default list item 1</li>
@@ -190,19 +186,6 @@ Display items horizontally with no divider.
     <li>Default list item 3</li>
   </cdr-list>
 ```
-</template>
-
-<template slot="compact">
-
-```html
-  <cdr-list modifier="inline compact">
-    <li>Compact list item 1</li>
-    <li>Compact list item 2</li>
-    <li>Compact list item 3</li>
-  </cdr-list>
-```
-
-</template>
 
 </cdr-doc-example-code-pair>
 
@@ -212,8 +195,6 @@ Display items horizontally, separated by a bullet character.
 
 <cdr-doc-example-code-pair :codeMaxHeight="false" repository-href="/src/components/list" :sandbox-data="$page.frontmatter.sandboxData" >
 
-<template slot="Default">
-
 ```html
   <cdr-list modifier="inline unordered">
     <li>Default list item 1</li>
@@ -221,19 +202,6 @@ Display items horizontally, separated by a bullet character.
     <li>Default list item 3</li>
   </cdr-list>
 ```
-</template>
-
-<template slot="compact">
-
-```html
-  <cdr-list modifier="inline compact unordered">
-    <li>Compact list item 1</li>
-    <li>Compact list item 2</li>
-    <li>Compact list item 3</li>
-  </cdr-list>
-```
-
-</template>
 
 </cdr-doc-example-code-pair>
 


### PR DESCRIPTION
this page is the only one exhibiting the bug from CDR-889,
and is also the only one to pass multiple slots into code pairs. These 2 examples will fail to render if you navigate directly to the list page.

the code pair component only shows the first slot anyways.

can't test with cdr-docs-preview as that isn't set up to handle the routing direct to a page besides landing/index.html. Verified that this works locally by editing `config.js` to set the base to root: `base: "/"`, running `npm build`, navigating into docs/.vuepress/dist, and running a web server
  