### PR TITLE
Stub out spring release notes

### DIFF
--- a/docs/release-notes/spring-2020/README.md
+++ b/docs/release-notes/spring-2020/README.md
@@ -42,17 +42,18 @@
 ## Deprecations
 
 ### Type Token Mixins
+
 #### Text Tokens
-| Deprecated token/mixin  | Equivalent token/mixin       |
-|-------------------------|------------------------------|
-| cdr-text-utility        | cdr-text-utility-sans        |
-| cdr-text-utility-strong | cdr-text-utility-sans-strong |
+| Deprecated token/mixin   | Equivalent token/mixin       |
+|--------------------------|------------------------------|
+| cdr-text--utility        | cdr-text-utility-sans        |
+| cdr-text--utility-strong | cdr-text-utility-sans-strong |
 
 ### Type Utility classes
-| Deprecated class name   | Equivalent class name        |
-|-------------------------|------------------------------|
-| cdr-text-utility        | cdr-text-utility-sans        |
-| cdr-text-utility-strong | cdr-text-utility-sans-strong |
+| Deprecated class name   | Equivalent class name         |
+|-------------------------|-------------------------------|
+| cdr-text-utility        | cdr-text--utility-sans        |
+| cdr-text-utility-strong | cdr-text--utility-sans-strong |
 
 ## Removals
 

--- a/docs/release-notes/spring-2020/README.md
+++ b/docs/release-notes/spring-2020/README.md
@@ -1,0 +1,61 @@
+---
+{
+  "title": "Winter 2020 Release",
+  "title_metadata": false,
+  "layout_type": "LayoutArticle",
+  "summary": false,
+  "breadcrumbs": [
+    {
+      "text": "4.x.x Release Notes"
+    }
+  ],
+}
+---
+
+<cdr-doc-table-of-contents-shell parentSelector='h2' childSelector='h3'>
+
+
+## Update Steps
+
+### For a Micro-Site
+
+- Update to `@rei/cedar` ^5.0.0
+
+### For a Component Package
+
+- Update to `@rei/cedar` ^5.0.0
+
+## 5.0.0
+
+## New Features
+
+### TODO: new features here
+
+## Bug Fixes
+
+### TODO: bug fixes here
+
+## Breaking Changes
+
+### TODO: breaking changes here
+
+## Deprecations
+
+### Type Token Mixins
+#### Text Tokens
+| Deprecated token/mixin  | Equivalent token/mixin       |
+|-------------------------|------------------------------|
+| cdr-text-utility        | cdr-text-utility-sans        |
+| cdr-text-utility-strong | cdr-text-utility-sans-strong |
+
+### Type Utility classes
+| Deprecated class name   | Equivalent class name        |
+|-------------------------|------------------------------|
+| cdr-text-utility        | cdr-text-utility-sans        |
+| cdr-text-utility-strong | cdr-text-utility-sans-strong |
+
+## Removals
+
+### TODO: things removed (deprecated Fall 2019)
+
+</cdr-doc-table-of-contents-shell>


### PR DESCRIPTION
I thought we could compile the release notes as we go so we are less likely to miss something at the end