### PR TITLE
Add token page, de-dupe some existing token examples

### DIFF
--- a/docs/.vuepress/components/MixinSorter.vue
+++ b/docs/.vuepress/components/MixinSorter.vue
@@ -1,0 +1,26 @@
+
+<script>
+import has from 'lodash/has';
+import MixinToken from './MixinToken';
+import MixinTypography from './MixinTypography';
+
+export default {
+  name: 'PropSorter',
+  functional: true,
+  props: {
+    prop: [Array, Object],
+  },
+  render(h, ctx) {
+    function tokenComponent() {
+      const propExample = has(ctx.props.prop[0], 'docs.example') ? ctx.props.prop[0].docs.example : 'token';
+      if (propExample === 'text') return MixinTypography;
+      
+      return MixinToken;
+    }
+    return h(
+      tokenComponent(),
+      { ...ctx },
+      ctx.children);
+  },
+};
+</script>

--- a/docs/.vuepress/components/MixinToken.vue
+++ b/docs/.vuepress/components/MixinToken.vue
@@ -1,0 +1,17 @@
+<template>
+  <tr>
+    <td></td>
+    <td></td>
+    <td>mixin</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'MixinToken'
+}
+</script>
+
+<style>
+
+</style>

--- a/docs/.vuepress/components/MixinTypography.vue
+++ b/docs/.vuepress/components/MixinTypography.vue
@@ -1,0 +1,44 @@
+<template>
+  <tr>
+    <td>
+      <span :style="mixinStyles(prop)">Get outside with REI</span>
+    </td>
+    <td>
+      <p v-if="isDeprecated">---DEPRECATED---</p>
+      {{mixinName}}
+    </td>
+    <td>mixin</td>
+  </tr>
+</template>
+
+<script>
+import kebab from 'lodash/kebabCase';
+
+export default {
+  name: 'MixinTypography',
+  props: {
+    prop: [Array, Object],
+  },
+  methods: {
+    mixinStyles(s) {
+      let final = {};
+      s.forEach(o => {
+        final[o.property]= o.value;
+      })
+      return final;
+    }
+  },
+  computed: {
+    mixinName() {
+      return kebab(this.prop[0].mixin);
+    },
+    isDeprecated() {
+      return this.prop[0].attributes.deprecated;
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/docs/.vuepress/components/TokenMotionExample.vue
+++ b/docs/.vuepress/components/TokenMotionExample.vue
@@ -2,22 +2,22 @@
   <div class="token-motion-example">
     <div class="animation-controls" v-if="!useGroupAnimate">
       <cdr-button
-        @click="animate = true" 
+        @click="animate = true"
         :icon-only="true"
         v-show="animationPlayState === 'paused'"
       >
-        <cdr-icon 
-          use="#play-fill" 
-          alt="Play animation" 
+        <cdr-icon
+          use="#play-fill"
+          alt="Play animation"
         />
       </cdr-button>
       <cdr-button 
-        @click="animate = false" 
+        @click="animate = false"
         :icon-only="true"
         v-show="animationPlayState === 'running'"
       >
-        <cdr-icon 
-          use="#pause-fill" 
+        <cdr-icon
+          use="#pause-fill"
           alt="Pause animation"
         />
       </cdr-button>

--- a/docs/.vuepress/components/TokenSorter.vue
+++ b/docs/.vuepress/components/TokenSorter.vue
@@ -1,0 +1,42 @@
+<script>
+import has from 'lodash/has';
+import TokenDefault from './TokenTypeDefault';
+import TokenColor from './TokenTypeColor';
+import TokenSpace from './TokenTypeSpace';
+import TokenRadius from './TokenTypeRadius';
+import TokenProminence from './TokenTypeProminence';
+import TokenInset from './TokenTypeInset';
+import TokenBreakpoint from './TokenTypeBreakpoint';
+import TokenTypography from './TokenTypeTypography';
+import TokenMotion from './TokenTypeMotion';
+export default {
+  name: 'TokenSorter',
+  functional: true,
+  props: {
+    prop: Object,
+  },
+  render(h, ctx) {
+    function tokenComponent() {
+      const propExample = has(ctx.props.prop, 'docs.example') ? ctx.props.prop.docs.example : 'token';
+      if (propExample === 'color') return TokenColor;
+      if (propExample === 'spacing') return TokenSpace;
+      if (propExample === 'sizing') return TokenSpace;
+      if (propExample === 'radius') return TokenRadius;
+      if (propExample === 'prominence') return TokenProminence;
+      if (propExample === 'inset') return TokenInset;
+      if (propExample === 'breakpoint') return TokenBreakpoint;
+      if (propExample === 'text') return TokenTypography;
+      if (
+        propExample === 'timing'
+        || propExample === 'duration'
+      ) return TokenMotion;
+      
+      return TokenDefault;
+    }
+    return h(
+      tokenComponent(),
+      { ...ctx },
+      ctx.children);
+  },
+};
+</script>

--- a/docs/.vuepress/components/TokenTypeBreakpoint.vue
+++ b/docs/.vuepress/components/TokenTypeBreakpoint.vue
@@ -1,0 +1,25 @@
+<template>
+  <tr>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+    <td>
+      <!-- <div class="breakpoint-example" :style="{width: prop.value}"/> -->
+    </td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TypeBreakpoint',
+  props: {
+    prop: Object,
+  },
+};
+</script>
+
+<style>
+  .breakpoint-example {
+    background-color: black;
+    height: 20px;
+  }
+</style>

--- a/docs/.vuepress/components/TokenTypeColor.vue
+++ b/docs/.vuepress/components/TokenTypeColor.vue
@@ -1,0 +1,30 @@
+<template>
+  <tr>
+    <td width="64"> <div class="color-example" :style="{backgroundColor: prop.value}"/> </td>
+    <td>
+      <cdr-text><b>{{ prop.name }}</b></cdr-text>
+      <cdr-text v-if="prop.docs.description && description">{{ prop.docs.description }}</cdr-text>
+    </td>
+    <td width="160">{{ prop.value }}</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TypeColor',
+  props: {
+    prop: Object,
+    description: Boolean,
+  },
+};
+</script>
+
+<style>
+  .color-example {
+    margin: 0 auto;
+    border: 1px solid gray;
+    border-radius: 2px;
+    height: 48px;
+    width: 48px;
+  }
+</style>

--- a/docs/.vuepress/components/TokenTypeDefault.vue
+++ b/docs/.vuepress/components/TokenTypeDefault.vue
@@ -1,0 +1,19 @@
+<template>
+  <tr>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+    <td></td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TokenTypeDefault',
+  props: {
+    prop: Object,
+  },
+};
+</script>
+
+<style>
+</style>

--- a/docs/.vuepress/components/TokenTypeInset.vue
+++ b/docs/.vuepress/components/TokenTypeInset.vue
@@ -1,0 +1,55 @@
+<template>
+  <tr>
+    <td>
+      <div class="inset-example" :style="{boxShadow: inset, padding: pad}">content</div>
+    </td>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TypeInset',
+  props: {
+    prop: Object,
+  },
+  computed: {
+    pad() {
+      const val = this.prop.value;
+      if (val.indexOf(' ') <= 0) {
+        return `${val} ${val}`;
+      } else if (val.indexOf('*') > 0) {
+        let [x, y] = val.split(') '); // eslint-disable-line
+        return `${x}) ${y}`;
+      }
+      const [x, y] = val.split(' ');
+      return `${x} ${y}`;
+    },
+    inset() {
+      const val = this.prop.value;
+      if (val.indexOf(' ') <= 0) {
+        return this.getInset(val, val, `-${val}`, `-${val}`);
+      } else if (val.indexOf('*') > 0) {
+        let [x, y] = val.split(') '); // eslint-disable-line
+        const negx = `${x.slice(0, 5)}-${x.slice(5)})`;
+        return this.getInset(`${x})`, y, negx, `-${y}`);
+      }
+      const [x, y] = val.split(' ');
+      return this.getInset(x, y, `-${x}`, `-${y}`);
+    },
+  },
+  methods: {
+    getInset(posy, posx, negy, negx) {
+      // console.log(posx, posy, negx, negy);
+      return `inset ${negx} ${negy} 0 rgb(199, 220, 191), inset ${posx} ${posy} 0 rgb(199, 220, 191)`;
+    },
+  },
+};
+</script>
+
+<style>
+.inset-example {
+  background-color: beige;
+}
+</style>

--- a/docs/.vuepress/components/TokenTypeMixin.vue
+++ b/docs/.vuepress/components/TokenTypeMixin.vue
@@ -1,0 +1,22 @@
+<template>
+  <tr>
+    <td></td>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TypeMixin',
+  props: {
+    prop: Object,
+  },
+};
+</script>
+
+<style>
+  .typography-values {
+    margin-bottom: 0;
+  }
+</style>

--- a/docs/.vuepress/components/TokenTypeMotion.vue
+++ b/docs/.vuepress/components/TokenTypeMotion.vue
@@ -1,0 +1,32 @@
+<template>
+  <tr>
+    <td>
+      <token-motion-example :prop="prop" />
+    </td>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+  </tr>
+</template>
+
+<script>
+import TokenMotionExample from './TokenMotionExample';
+
+export default {
+  name: 'TypeMotion',
+  components: {
+    TokenMotionExample,
+  },
+  props: {
+    prop: Object,
+  },
+  data() {
+    return {
+      animate: false
+    }
+  },
+};
+</script>
+
+<style lang="scss">
+
+</style>

--- a/docs/.vuepress/components/TokenTypeProminence.vue
+++ b/docs/.vuepress/components/TokenTypeProminence.vue
@@ -1,0 +1,35 @@
+<template>
+  <tr>
+    <td>
+      <div class="prominence-wrap">
+        <div class="prominence-example" :style="{boxShadow: prop.value}"/>
+      </div>
+    </td>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TypeProminence',
+  props: {
+    prop: Object,
+  },
+};
+</script>
+
+<style>
+  .prominence-wrap {
+    display: inline-block;
+    background-color: lightgray;
+    padding: 20px;
+  }
+
+  .prominence-example {
+    background-color: white;
+    width: 32px;
+    height: 32px;
+    box-shadow: 0rem 0rem 0rem 0rem #1a1a1a 0.2;
+  }
+</style>

--- a/docs/.vuepress/components/TokenTypeRadius.vue
+++ b/docs/.vuepress/components/TokenTypeRadius.vue
@@ -1,0 +1,26 @@
+<template>
+  <tr>
+    <td>
+      <div class="radius-example" :style="{borderRadius: prop.value}"/>
+    </td>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TypeRadius',
+  props: {
+    prop: Object,
+  },
+};
+</script>
+
+<style>
+  .radius-example {
+    background-color: black;
+    width: 32px;
+    height: 32px;
+  }
+</style>

--- a/docs/.vuepress/components/TokenTypeSpace.vue
+++ b/docs/.vuepress/components/TokenTypeSpace.vue
@@ -1,0 +1,46 @@
+<template>
+  <tr>
+    <td>
+      <div class="space-example" :style="{width: prop.value}"/>
+    </td>
+    <td>{{prop.name}}</td>
+    <td>{{prop.value}}</td>
+  </tr>
+</template>
+
+<script>
+export default {
+  name: 'TypeSpace',
+  props: {
+    prop: Object,
+  },
+};
+</script>
+
+<style lang="scss">
+  .space-example {
+    height: 1px;
+    background-color: black;
+    position: relative;
+
+    &::before {
+      content: '';
+      position: absolute;
+      height: 5px;
+      width: 1px;
+      background-color: black;
+      top: -2px;
+      left: -1px;
+    }
+
+    &::after {
+      content: '';
+      position: absolute;
+      height: 5px;
+      width: 1px;
+      background-color: black;
+      top: -2px;
+      right: -1px;
+    }
+  }
+</style>

--- a/docs/.vuepress/components/TokenTypeTypography.vue
+++ b/docs/.vuepress/components/TokenTypeTypography.vue
@@ -1,0 +1,25 @@
+<template>
+  <tr>
+    <td>{{name}}</td>
+    <td>
+      {{prop.value}}
+    </td>
+    <td>
+      part of "{{kebab(prop.mixin)}}" mixin
+    </td>
+  </tr>
+</template>
+
+<script>
+
+export default {
+  name: 'TypeTypography',
+  props: {
+    name: String,
+    prop: Object,
+  }
+};
+</script>
+
+<style>
+</style>

--- a/docs/.vuepress/components/TokensCategory.vue
+++ b/docs/.vuepress/components/TokensCategory.vue
@@ -1,0 +1,93 @@
+<template>
+  <div class="cdr-container ">
+    <h3 class="category-title">{{ categoryTitle }}</h3>
+
+    <div
+      v-for="(v,k) in typeData"
+      :key="k"
+    >
+      <h4
+        v-if="k !== 'undefined'"
+        class="type-title"
+      >{{k}}</h4>
+
+      <table
+        v-if="otherTokens(v).length > 0"
+        class="prop-table"
+        data-backstop="capture"
+      >
+        <tbody class="prop-tbody">
+          <token-sorter
+            v-for="(v,k) in otherTokens(v)"
+            :key="k"
+            :prop="v"
+          />
+        </tbody>
+      </table>
+
+      <template v-if="Object.keys(mixinTokens(v)).length > 0">
+        <table
+          v-for="(v,k) in mixinTokens(v)"
+          :key="k"
+          class="prop-table mixins"
+          data-backstop="capture"
+        >
+          <tbody class="prop-tbody">
+            <mixin-sorter
+              :prop="v"
+            />
+            <type-mixin
+              v-for="(v, idx) in v"
+              :key="`mixin${v.name}${idx}`"
+              :prop="v"
+            />
+          </tbody>
+        </table>
+      </template>
+    </div>
+  </div>
+</template>
+
+<script>
+import TokenSorter from './TokenSorter';
+import MixinSorter from './MixinSorter';
+import TypeMixin from './TokenTypeMixin';
+import groupBy from 'lodash/groupBy';
+import filter from 'lodash/filter';
+import has from 'lodash/has';
+
+
+export default {
+  name: 'TokensCategory',
+  props: {
+    categoryData: Array,
+    categoryTitle: String,
+  },
+  components: {
+    TokenSorter,
+    MixinSorter,
+    TypeMixin,
+  },
+  computed: {
+    typeData() {
+      return groupBy(this.categoryData, 'docs.type');
+    }
+  },
+  methods: {
+    mixinTokens(arr) {
+      const res = filter(arr, (o) => {
+        return has(o, 'mixin');
+      });
+
+      return groupBy(res, 'mixin');
+    },
+    otherTokens(arr) {
+      const res = filter(arr, (o) => {
+        return !has(o, 'mixin');
+      });
+
+      return res;
+    },
+  }
+}
+</script>

--- a/docs/.vuepress/components/TokensColor.vue
+++ b/docs/.vuepress/components/TokensColor.vue
@@ -3,17 +3,15 @@
   <slot />
   <table>
     <tbody>
-      <tr
+      <template
         v-for="token in colorTokensByType"
         v-if="token.attributes.deprecated !== true"
       >
-        <td width="64"> <div class="color-example" :style="{backgroundColor: token.value}"/> </td>
-        <td>
-          <cdr-text><b>{{ token.name }}</b></cdr-text>
-          <cdr-text v-if="token.docs.description">{{ token.docs.description }}</cdr-text>
-        </td>
-        <td width="160">{{ token.value }}</td>
-      </tr>
+        <token-type-color
+          :prop="token"
+          description
+        />
+      </template>
     </tbody>
   </table>
 </div>
@@ -21,12 +19,16 @@
 
 <script>
 import tokenData from '@rei/cdr-tokens/dist/json/platform-tokens.json';
+import TokenTypeColor from './TokenTypeColor';
 import groupBy from 'lodash/groupBy';
 import filter from 'lodash/filter';
 import endsWith from 'lodash/endsWith';
 
 export default {
   name: 'TokensColor',
+  components: {
+    TokenTypeColor,
+  },
   props: {
     type: String,
     mode: {

--- a/docs/.vuepress/components/TokensMotion.vue
+++ b/docs/.vuepress/components/TokensMotion.vue
@@ -3,23 +3,23 @@
     <div
       v-if="comparisonView"
     >
-      <cdr-button 
+      <cdr-button
         :icon-only="true"
-        @click="animate = true" 
+        @click="animate = true"
         v-show="!animate"
       >
-        <cdr-icon 
-          use="#play-fill" 
-          alt="Play animation" 
+        <cdr-icon
+          use="#play-fill"
+          alt="Play animation"
         />
       </cdr-button>
-      <cdr-button 
+      <cdr-button
         :icon-only="true"
-        @click="animate = false" 
+        @click="animate = false"
         v-show="animate"
       >
-        <cdr-icon 
-          use="#pause-fill" 
+        <cdr-icon
+          use="#pause-fill"
           alt="Pause animation"
         />
       </cdr-button>
@@ -27,9 +27,9 @@
         <tr v-for="token in motionTokensByType[motionType]">
           <td>
             <token-motion-example
-              :prop="token" 
-              :use-group-animate="true" 
-              :group-animate="animate" 
+              :prop="token"
+              :use-group-animate="true"
+              :group-animate="animate"
             />
           </td>
           <td>
@@ -42,7 +42,6 @@
     <div
       v-else
       v-for="token in motionTokensByType[motionType]"
-      class="something"
     >
       <table class="motion-token-definition">
         <tr><td><strong>{{ token.name }}</strong></td></tr>

--- a/docs/.vuepress/components/TokensPage.vue
+++ b/docs/.vuepress/components/TokensPage.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <p>Accurate for @rei/cdr-tokens version {{ version }}</p>
+    <div
+      v-for="(data, platform) in filteredTokens"
+      :key="platform"
+    >
+      <h2 class="platform-title">Platform: {{platform}}</h2>
+
+      <div v-if="platform === 'global'">
+        <p>Global token names are converted to platform specific variable naming but only shown here for SCSS/LESS:</p>
+        <ul>
+          <li>SCSS/LESS: kebab-case</li>
+          <li>JS (commonjs): camelCase</li>
+          <li>JS (esm): PascalCase</li>
+          <li>Android: snake_case</li>
+          <li>iOS: PascalCase</li>
+        </ul>
+        <p>Global token values are converted to platform specific units in the platform's package but only shown here for web</p>
+      </div>
+
+      <hr>
+
+      <template v-for="(v, k) in data">
+        <tokens-category
+          v-if="v.length > 0"
+          :key="k"
+          :category-title="k"
+          :category-data="v"
+        />
+      </template>
+    </div>
+  </div>
+</template>
+
+<script>
+import tokenPackage from '@rei/cdr-tokens/package.json';
+import PlatformTokens from '@rei/cdr-tokens/dist/json/platform-tokens.json';
+import TokensCategory from './TokensCategory';
+import filter from 'lodash/filter';
+
+export default {
+  name: 'TokensPage',
+  components: {
+    TokensCategory,
+  },
+  data() {
+    return {
+      version: tokenPackage.version,
+      PlatformTokens,
+    };
+  },
+  computed: {
+    // filter out deprecated tokens
+    filteredTokens() {
+      const filteredTokens = {};
+
+      Object.keys(this.PlatformTokens).forEach(platform => {
+        filteredTokens[platform] = {};
+        Object.keys(this.PlatformTokens[platform]).forEach(category => {
+          filteredTokens[platform][category] = filter(this.PlatformTokens[platform][category], ['attributes.deprecated', false])
+        });
+      });
+
+      return filteredTokens;
+    },
+  },
+}
+</script>
+
+<style>
+
+</style>

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -141,6 +141,10 @@ module.exports = {
           { text: "Iconography", link: "/icons/iconography/" }
         ]
       },
+      {
+        text: "Tokens",
+        link: "/tokens/"
+      },
       {text: "Report an Issue", link: 'https://airtable.com/shr3wSPCYQbycVx7i'},
       {text: "Request a Feature", link: 'https://airtable.com/shrcbq9CHthuMO7AC'},
     ]

--- a/docs/tokens/README.md
+++ b/docs/tokens/README.md
@@ -1,0 +1,18 @@
+---
+{
+  "title": "Tokens",
+  "title_metadata": false,
+  "layout_type": "LayoutArticle",
+  "summary": false,
+  "breadcrumbs": [
+    {
+      "text": "Tokens/"
+    }
+  ],
+}
+---
+<cdr-doc-table-of-contents-shell parentSelector='h2' childSelector='h3'>
+
+<tokens-page />
+
+</cdr-doc-table-of-contents-shell>


### PR DESCRIPTION
This is largely a direct lift from the existing token page with some changes to which tokens are displayed (no deprecated tokens here).

We had pieces of tokens displayed elsewhere on the site too and I tried to de-dupe display logic where I could...some of them have completely different layouts though so it wasn't always possible.

I'm sure there will be lots to say about formatting this once design really looks at it but I guess we'll address that later.