### PR TITLE
Add spring notes

### DIFF
--- a/docs/release-notes/fall-2019/README.md
+++ b/docs/release-notes/fall-2019/README.md
@@ -47,8 +47,7 @@ A new [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) has been create
 - Allows consumers to pick and choose which icons to include in their sprite sheet rather than being forced to load all of them
 - Cedar no longer has to distribute SVG assets, which simplifies our build process
 - Decreases bundle size as sprite sheets are now loaded inline in the HTML rather than being included in the JavaScript bundle
-
-For more information on updating your icon usage, see the [deprecated icon components](#deprecated-icon-components) section.
+- Consumers can still load the inline icon components from `@rei/cedar`
 
 ### Cedar Component Variables 1.0.0
 
@@ -214,6 +213,8 @@ Vue expects event names to use kebab case and not camel case, so the `tabChange`
 ## Deprecations
 
 Whenever possible and practical, the Cedar team will deprecate features rather than issue outright breaking changes in order to allow teams some time to update their codebases. Features will be removed from the doc site when they are deprecated to ensure that they are no longer used in new code.
+
+NOTE: The deprecated typohraphy tokens and mixins listed below received new mappings as part of the [Winter 2020 Release](https://rei.github.io/rei-cedar-docs/release-notes/winter-2020/#updated-deprecation-mappings)
 
 ### Deprecated Typography/Headings
 
@@ -422,34 +423,6 @@ The utility visibility and accessibility classes have been deprecated and update
 | cdr-sr-only-focusable         | cdr-display-sr-focusable    |
 
 
-### Deprecated Icon Components
-
-With the release of the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/), we are deprecating the "single icon" components (i.e, `IconArrowDown`, `IconCart`, etc.) as well as  `CdrIconSprite`. These components will be removed in a future release.  
-
-If you were using the single icon components, you should update them to use `CdrIcon` and the `use` attribute instead, and follow the instructions below to create and load a sprite sheet.
-
-If you were using CdrIconSprite, you should use the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) to create an SVG file containing all the icons required for your application. You will then need to render that SVG file somewhere in your application. The best place to do this is inline with your root HTML template rather than in the JavaScript.
-
-This ensures that when your app is server-side rendered, the sprite sheet is only rendered one time, rather than being included in both the HTML and the JavaScript files. There are various ways to do this depending on how your application is built, but if you are using the standard REI micro-site architecture built on spring-boot or thymeleaf, you can load the sprite sheet as follows:
-
-1. Create a new template named `resources/templates/icon-sprite.html` and copy your generated SVG file into it:
-
-```
-<!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-  <body>
-    <div th:remove="tag" th:fragment="icon-sprite">
-      <!-- copy paste your generated SVG file here -->
-    </div>
-  </body>
-</html>
-```
-
-2. Render the sprite sheet somewhere in your app (note this needs to be rendered on every page that contains icons):
-
-```
-<div th:remove="tag" th:insert="~{icon-sprite :: icon-sprite}"></div>
-```
 ### Breadcrumb Truncation/SSR
 
 In order to fix an issue with server-side rendering, as well as to simplify the API of [CdrBreadcrumb](../../components/breadcrumb/), we have removed the `truncationThreshold` and `truncationXSThreshold` attributes. Instead, the `truncationEnabled` attr can be used to control whether or not the breadcrumb should be truncated. This change will not break any existing consumers of breadcrumb even if they are using those attributes.

--- a/docs/release-notes/spring-2020/README.md
+++ b/docs/release-notes/spring-2020/README.md
@@ -41,6 +41,26 @@ CdrLink previously supported theming by setting an `on-dark` or `on-light` CSS c
 
 ## Deprecations
 
+#### Text Tokens
+| Deprecated token/mixin   | Equivalent token/mixin       |
+|--------------------------|------------------------------|
+| cdr-text-utility-n00         | cdr-text-utility-sans-n00         |
+| cdr-text-utility-strong-n00  | cdr-text-utility-sans-strong-n00  |
+
+### Type Utility classes
+| Deprecated class name   | Equivalent class name         |
+|-------------------------|-------------------------------|
+| cdr-text-utility-n00        | cdr-text--utility-sans-n00         |
+| cdr-text-utility-strong-n00 | cdr-text--utility-sans-strong-n00  |
+
+
+### CdrText Modifiers
+| Deprecated class name   | Equivalent class name         |
+|-------------------------|-------------------------------|
+| utility-n00                 | utility-sans-n00                  |
+| utility-strong-n00          | utility-sans-strong-n00 .         |
+
+
 ### Removals
 
 In accordance with our deprecation policy, features that were deprecated in the [Fall 2019 release](https://rei.github.io/rei-cedar-docs/release-notes/fall-2019/#deprecations) have been removed from Cedar.

--- a/docs/release-notes/spring-2020/README.md
+++ b/docs/release-notes/spring-2020/README.md
@@ -1,0 +1,51 @@
+---
+{
+  "title": "Spring 2020 Release",
+  "title_metadata": false,
+  "layout_type": "LayoutArticle",
+  "summary": false,
+  "breadcrumbs": [
+    {
+      "text": "5.x.x Release Notes"
+    }
+  ],
+}
+---
+
+<cdr-doc-table-of-contents-shell parentSelector='h2' childSelector='h3'>
+
+
+## Update Steps
+
+If you are not already on `@rei/cedar` >= 2.x.x, you will first need to [upgrade your project](../summer-2019/) to the single-package version of Cedar.
+
+### For a Micro-Site
+
+- Update to `@rei/cedar` ^5.0.0
+- If your project depends on any shared component packages (i.e, FEDPACK, FEDCOMP, FEDPAGES), you will want to update those packages to the new version of Cedar and febs before updating your micro-site
+
+### For a Component Package
+
+- Update to `@rei/cedar` ^5.0.0
+- Ensure your component is using `@rei/febs` ^7.1.0 for it's prod and dev build systems
+
+## New Features
+
+## Bug Fixes
+
+## Breaking Changes
+
+### CdrLink Theming Removed
+
+CdrLink previously supported theming by setting an `on-dark` or `on-light` CSS class on a container element. Due to the new color scale this feature was not possible to support in a consistent way and has been removed.
+
+## Deprecations
+
+### Removals
+
+In accordance with our deprecation policy, features that were deprecated in the [Fall 2019 release](https://rei.github.io/rei-cedar-docs/release-notes/fall-2019/#deprecations) have been removed from Cedar.
+
+- The cdr-text modifiers for display, heading-small/medium/large, and subheading, as well as cdr-tokens mixins for `cdr-text-header-n` and `spruce-display` should be updated according to the typography mappings from the [Winter 2020 release](https://rei.github.io/rei-cedar-docs/release-notes/winter-2020/#updated-deprecation-mappings) rather than the ones in the Fall 2019 release notes.
+- Alignment and display utilities should be re-mapped to their new naming structure
+
+</cdr-doc-table-of-contents-shell>


### PR DESCRIPTION
- updates the fall release notes to add a note about the re-mappings in winter-2020 as well as the un-deprecation of inline icon components. Since the fall deprecations will be removed as part of this release, it seems important to call that out/fix it to avoid confusion.

- creates a release notes page for spring 2020 