### PR TITLE
Fixed link paths

### DIFF
--- a/docs/foundation/color/README.md
+++ b/docs/foundation/color/README.md
@@ -21,7 +21,7 @@ Color design tokens represent the fundamental decisions of Cedar’s visual lang
   - Stores color specifications using variable names, not hard-coded values such as hex values for color
   - Specifies a hierarchical and semantically-defined system
 
-The color values in Cedar have been carefully selected and tested to meet WCAG accessibility requirements for contrast and color. Using colors outside of this palette may result in an inaccessible experience for some users, and should be avoided when possible. Learn more about accessibility in the Cedar Design System in the [Accessibility Foundation](../../accessibility/) article as well as throughout the component guidelines. 
+The color values in Cedar have been carefully selected and tested to meet WCAG accessibility requirements for contrast and color. Using colors outside of this palette may result in an inaccessible experience for some users, and should be avoided when possible. Learn more about accessibility in the Cedar Design System in the [Accessibility Foundation](../../foundation/accessibility/) article as well as throughout the component guidelines. 
 
 <br/>
 <hr>
@@ -31,7 +31,7 @@ Below is a list of color tokens with descriptions and values. Web and mobile col
   - **For Android:** cdr_color_text_primary
   - **For iOS:** CdrColorTextPrimary  
 
-For more information on naming structure for design token, visit the [Design Tokens](https://rei.github.io/rei-cedar-docs/components/design-tokens/#naming-structure-for-design-tokens/) page.
+For more information on naming structure for design token, visit the [Design Tokens](../../components/design-tokens/#naming-structure-for-design-tokens/) overview.
 
 <tokens-color />
 


### PR DESCRIPTION
Hopefully I added these relative URL paths correctly:
- fixed link for Accessibility Foundation article 
- changed link to Design Tokens to relative URL