### PR TITLE
apply generic link styles

### DIFF
--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -232,6 +232,11 @@ div[class^='language-'] {
   margin-top: $cdr-space-two-x;
 }
 
+.page a:not([class*="cdr-link"]):not([class="header-anchor"]) {
+  color: pink;
+  @include cdr-link-base-mixin;
+}
+
 /*
 Generic Styling, for Desktops/Laptops  this is for markdown table display */
 

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -233,7 +233,6 @@ div[class^='language-'] {
 }
 
 .page a:not([class*="cdr-link"]):not([class="header-anchor"]) {
-  color: pink;
   @include cdr-link-base-mixin;
 }
 
@@ -241,7 +240,6 @@ div[class^='language-'] {
 Generic Styling, for Desktops/Laptops  this is for markdown table display */
 
 table:not([class*="cdr-table"]) {
-  color: pink;
   @include cdr-table-base-mixin;
   @include cdr-table-full-width-mixin;
   @include cdr-table-striped-mixin;

--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -235,7 +235,7 @@ Displays status for checkbox group by indicating that some of the sub-selections
 
 ```html
 <div>
-  <cdr-checkbox v-model="ex1" indeterminate>Indeterminate</cdr-checkbox>
+  <cdr-checkbox v-model="ex1" :indeterminate="!ex1">Indeterminate</cdr-checkbox>
 </div>
 ```
 
@@ -272,7 +272,7 @@ Custom styles for checkboxes.
 
 ## Accessibility
 
-Many WCAG requirements are contextual to their implementation. 
+Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:
 
 - Each checkbox must be focusable and keyboard accessible:


### PR DESCRIPTION
applying this to every `a` messes up the left hand nav, anchor links, etc.
Might be other elements we need to exclude this styling from 👀 


ALSO: updates the indeterminate example to make it look less broken. Long term we should consider updating the code snippet logic to just accept a full `.vue` component rather than the weirdness it currently does.