### PR TITLE
remove link styling

### DIFF
--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -232,10 +232,6 @@ div[class^='language-'] {
   margin-top: $cdr-space-two-x;
 }
 
-.page a:not([class*="cdr-link"]):not([class="header-anchor"]):not(.cdr-doc-example-code-pair a) {
-  @include cdr-link-base-mixin;
-}
-
 /*
 Generic Styling, for Desktops/Laptops  this is for markdown table display */
 


### PR DESCRIPTION
can't figure out a selector that will target all links except ones in code samples. Just turning this off for now.