### PR TITLE
delete card linked/position notes, no longer applicable

### DIFF
--- a/docs/release-notes/spring-2020/README.md
+++ b/docs/release-notes/spring-2020/README.md
@@ -62,10 +62,6 @@ We have added this wrapper component to better support the accessibility of acco
 
 We have updated CdrImg to accept event handlers. This is intended to support `onError` event handlers. See the [CdrImg docs](../../components/image/#error-event-handler) for more details and examples.
 
-### CdrCard Linked State
-
-CdrCard has been updated with a new `linked` property which can be used to add a hover effect to cards that are wrapped in a link. Any custom hover logic that you may have applied to instances of CdrCard should be removed in favor of using this new property. See the [CdrCard docs](../../components/card/#linked) for more details and examples.
-
 ### CdrModal Fullscreen
 
 CdrModal now shifts to a fullscreen view at the `xs` breakpoint, and will otherwise render at `640px` wide. Note that the `size` property  [has been removed from CdrModal](#cdrmodal-size-prop-removed) in order to accomodate this update.
@@ -143,7 +139,7 @@ CdrTabs has been updated so that the active tab underline no longer causes windo
 - When images are disabled, star icons are replaced with Unicode characters .
 - Star icon is visible in high contrast mode.
 - Screen reader text has been updated for each variant possible:
-  
+
 | Use Case | Screen Reader Text |
 |------------------|------------------|
 |linked rating stars with average and count: has reviews | View the (x) reviews with an average rating of #.## out of 5 stars|
@@ -158,7 +154,7 @@ CdrTabs has been updated so that the active tab underline no longer causes windo
 
 - Only the active tab is in the tab order. The user reaches the tabbed panel component by pressing the tab key until the active tab title receives focus.
 - Clicking on the tab title activates the tab and sets focus to the tab title.
-- Tab navigation will move from tab item to the associated panel. 
+- Tab navigation will move from tab item to the associated panel.
 - The currently selected tab list item has the state aria-selected="true".
 - Uses an unordered list structure.
 
@@ -188,10 +184,6 @@ CdrLink previously supported theming by setting an `on-dark` or `on-light` CSS c
 ### CdrButton OnDark Removed
 
 CdrButton previously accepted a prop named `on-dark` which could be used in conjunction with the `icon-only` prop to render a button with a background. This was intended to be used on dark backgrounds to make the icon button more visible and accessible. Due to the new color scale this feature was not possible to continue supporting as is, and has been replaced with a new [with-background](#cdrbutton-icon-only-variant) property.
-
-### CdrCard Position Update
-
-We have updated the CdrCard component to use `position: relative` in order to support upcoming work that will enable more complex card compositions. If you have been applying custom styling to instances of CdrCard this may cause conflicts with your implementation.
 
 ### CdrModal Size Prop Removed
 


### PR DESCRIPTION
Since we added the card link utility class, these release notes are no longer applicable