### PR TITLE
Burger iteration

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -76,6 +76,12 @@ export default {
     this.updateMetaTags(null, this.currentMetaTags)
   },
 
+  watch: {
+    $route() {
+      this.sideNavOpen = false;
+    }
+  },
+
   methods: {
     toggleSideNav() {
       this.sideNavOpen = !this.sideNavOpen;

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -50,6 +50,9 @@ export default {
       return [
         userPageClass
       ]
+    },
+    menuClass() {
+      return `cdr-doc-page-shell__side-navigation ${this.sideNavOpen ? 'cdr-doc-page-shell__side-navigation--open' : ''}`
     }
   },
 
@@ -71,11 +74,6 @@ export default {
 
   beforeDestroy () {
     this.updateMetaTags(null, this.currentMetaTags)
-  },
-  computed: {
-    menuClass() {
-      return `cdr-doc-page-shell__side-navigation ${this.sideNavOpen ? 'cdr-doc-page-shell__side-navigation--open' : ''}`
-    }
   },
 
   methods: {

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -55,6 +55,7 @@ body {
   .cdr-doc-page-shell__side-navigation {
     flex: 0 0 0;
     width: 0;
+    position: absolute;
   }
 
   .cdr-doc-side-navigation {


### PR DESCRIPTION
A couple easy iterations/improvements to the hamburger nav

- resolved the duplicate `computed` entries
- makes the menu close when user navigates
- makes the menu sit on top of the page when its opened rather than shifting everything to the right