### PR TITLE
fix cdr-tokens import in sandbox

### DIFF
--- a/utils/buildSandbox.js
+++ b/utils/buildSandbox.js
@@ -32,7 +32,7 @@ export default function makeMeASandbox(data, model) {
             // TODO: can we grab the preceding text to use for description?
           "description": "https://rei.github.io/rei-cedar-docs/",
           "dependencies": {
-            "@rei/cdr-tokens": packageJson.devDependencies['@rei/cdr-tokens'],
+            "@rei/cdr-tokens": packageJson.dependencies['@rei/cdr-tokens'],
             "@rei/cedar": packageJson.dependencies['@rei/cedar'],
             "vue": "^2.5.22"
           }

--- a/utils/buildSandbox.js
+++ b/utils/buildSandbox.js
@@ -89,7 +89,7 @@ function buildContent(data, model, fontImport) {
 }
 
 function buildScriptTag(data, model) {
-  const componentsImport = `import { ${data.components} } from "@rei/cedar";`;
+  const componentsImport = `import { ${data.components} } from "@rei/cedar/dist/cedar.mjs"; // NOTE: importing from '@rei/cedar/dist/cedar.mjs' to bypass a codesandbox bug. Please import from '@rei/cedar' in your code.`;
 
   return `
 ${data.components ? componentsImport : ''}


### PR DESCRIPTION
noticed the sandboxes currently load with an error because the cdr-tokens dep disappeared, this will fix the CSS side of that error

there is another unrelated JS bug in codesandbox that causes a different cdr-tokens related error https://github.com/codesandbox/codesandbox-client/issues/4456 

seems like codesandbox might be excluding anything named "node_modules" from the bundle it creates, which excludes the mini copy of cdr-tokens that we bundle into our ESM:
<img width="326" alt="Screen Shot 2020-06-24 at 10 30 15 AM" src="https://user-images.githubusercontent.com/48567940/85604007-bf5f3180-b605-11ea-8d8b-47b628e2a625.png">

We can bypass that by forcing the sandbox to import from `cedar.mjs` which is the un-tree-shakeable ESM bundle, as that bundle simply inlines the cdrTokens:
<img width="538" alt="Screen Shot 2020-06-24 at 10 50 26 AM" src="https://user-images.githubusercontent.com/48567940/85607011-8b394000-b608-11ea-9221-39756d4464c3.png">


