### PR TITLE
Burger modal

### DIFF
--- a/docs/.vuepress/components/LayoutArticle.vue
+++ b/docs/.vuepress/components/LayoutArticle.vue
@@ -47,6 +47,6 @@ export default {
 
   .cdr-doc-article-layout__body-inner {
     margin: 0 auto;
-    width: $cdr-doc-content-max-width;
+    max-width: $cdr-doc-content-max-width;
   }
 </style>

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -17,7 +17,7 @@
           <Navbar/>
         </div>
       </div>
-      <div class="cdr-doc-page-shell__body">
+      <div class="cdr-doc-page-shell__body" :style="bodyStyle">
         <div class="custom-layout" v-if="$page.frontmatter.layout_type">
           <component :is="$page.frontmatter.layout_type"/>
         </div>
@@ -54,6 +54,9 @@ export default {
     },
     menuClass() {
       return `cdr-doc-page-shell__side-navigation ${this.sideNavOpen ? 'cdr-doc-page-shell__side-navigation--open' : ''}`
+    },
+    bodyStyle() {
+      return this.sideNavOpen ? { position: 'fixed', overflow: 'hidden'} : {}
     }
   },
 

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -12,11 +12,12 @@
         <cdr-icon use="#navigation-menu"/>
       </cdr-button>
       <div :class="menuClass">
+        <div class="cdr-doc-side-navigation-overlay" @click="closeSideNav"></div>
         <div class="cdr-doc-side-navigation">
           <Navbar/>
         </div>
       </div>
-      <div class="cdr-doc-page-shell__body" @click="closeSideNav">
+      <div class="cdr-doc-page-shell__body">
         <div class="custom-layout" v-if="$page.frontmatter.layout_type">
           <component :is="$page.frontmatter.layout_type"/>
         </div>

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -12,7 +12,6 @@
         <cdr-icon use="#navigation-menu"/>
       </cdr-button>
       <div :class="menuClass">
-        <div class="cdr-doc-side-navigation-overlay" @click="closeSideNav"></div>
         <div class="cdr-doc-side-navigation">
           <Navbar/>
         </div>

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -16,7 +16,7 @@
           <Navbar/>
         </div>
       </div>
-      <div class="cdr-doc-page-shell__body" :style="bodyStyle">
+      <div :class="bodyClass">
         <div class="custom-layout" v-if="$page.frontmatter.layout_type">
           <component :is="$page.frontmatter.layout_type"/>
         </div>
@@ -34,6 +34,8 @@ import BackToTopBtn from './BackToTop.js';
 import Home from './Home.vue'
 import Navbar from './Navbar.vue'
 import { pathToComponentName } from '@app/util';
+import { debounce } from 'throttle-debounce';
+
 import '../cedar.js';
 export default {
   components: { Home, Navbar, BackToTopBtn },
@@ -54,8 +56,8 @@ export default {
     menuClass() {
       return `cdr-doc-page-shell__side-navigation ${this.sideNavOpen ? 'cdr-doc-page-shell__side-navigation--open' : ''}`
     },
-    bodyStyle() {
-      return this.sideNavOpen ? { position: 'fixed', overflow: 'hidden'} : {}
+    bodyClass() {
+      return `cdr-doc-page-shell__body ${this.sideNavOpen ? 'cdr-doc-page-shell__body--no-scroll' : ''}`
     }
   },
 
@@ -73,6 +75,10 @@ export default {
     this.currentMetaTags = []
     this.updateMeta()
 
+    window.addEventListener('resize', debounce(250, () => {
+      this.sideNavOpen = false;
+    }));
+
   },
 
   beforeDestroy () {
@@ -86,9 +92,6 @@ export default {
   },
 
   methods: {
-    closeSideNav() {
-      this.sideNavOpen = false;
-    },
     toggleSideNav() {
       this.sideNavOpen = !this.sideNavOpen;
     },

--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -16,7 +16,7 @@
           <Navbar/>
         </div>
       </div>
-      <div class="cdr-doc-page-shell__body">
+      <div class="cdr-doc-page-shell__body" @click="closeSideNav">
         <div class="custom-layout" v-if="$page.frontmatter.layout_type">
           <component :is="$page.frontmatter.layout_type"/>
         </div>
@@ -83,6 +83,9 @@ export default {
   },
 
   methods: {
+    closeSideNav() {
+      this.sideNavOpen = false;
+    },
     toggleSideNav() {
       this.sideNavOpen = !this.sideNavOpen;
     },

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -74,6 +74,11 @@ body {
   .cdr-doc-page-shell__body {
     max-width: 100%;
   }
+
+  .cdr-doc-page-shell__body--no-scroll {
+    position: fixed;
+    overflow: hidden;
+  }
 }
 
 .cdr-doc-side-navigation__logo-wrap {

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -4,7 +4,6 @@
 
 $side-navigation-logo-width: 162px;
 $side-navigation-width: 234px;
-$side-navigation-width-sm: $side-navigation-logo-width + 24px;
 
 html,
 body {
@@ -68,11 +67,11 @@ body {
   }
 
   .cdr-doc-page-shell__side-navigation--open {
-    flex: 0 0 $side-navigation-width-sm;
-    width: $side-navigation-width-sm;
+    flex: 0 0 $side-navigation-width;
+    width: $side-navigation-width;
 
     .cdr-doc-side-navigation {
-      width: $side-navigation-width-sm;
+      width: $side-navigation-width;
     }
 
     .cdr-doc-side-navigation-overlay {

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -22,7 +22,6 @@ body {
   flex: 0 0 $side-navigation-width;
   width: $side-navigation-width;
   z-index: 120;
-  transition: flex $cdr-duration-5-x, width $cdr-duration-5-x;
 }
 
 .cdr-doc-side-navigation {
@@ -67,23 +66,8 @@ body {
   }
 
   .cdr-doc-page-shell__side-navigation--open {
-    flex: 0 0 $side-navigation-width;
-    width: $side-navigation-width;
-
     .cdr-doc-side-navigation {
-      width: $side-navigation-width;
-    }
-
-    .cdr-doc-side-navigation-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      background-color: $cdr-color-background-modal-overlay;
-      backdrop-filter: blur($cdr-space-one-x);
-      opacity: 0.75;
-      transition: opacity $cdr-duration-5-x, background-color $cdr-duration-5-x;
+      width: 100%;
     }
   }
 

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -62,12 +62,29 @@ body {
     width: 0;
   }
 
+  .cdr-doc-side-navigation-overlay {
+    background-color: transparent;
+    opacity: 0;
+  }
+
   .cdr-doc-page-shell__side-navigation--open {
     flex: 0 0 $side-navigation-width-sm;
     width: $side-navigation-width-sm;
 
     .cdr-doc-side-navigation {
       width: $side-navigation-width-sm;
+    }
+
+    .cdr-doc-side-navigation-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: $cdr-color-background-modal-overlay;
+      backdrop-filter: blur($cdr-space-one-x);
+      opacity: 0.75;
+      transition: opacity $cdr-duration-5-x, background-color $cdr-duration-5-x;
     }
   }
 
@@ -277,7 +294,7 @@ table:not([class*="cdr-table"]) {
 
   &.back-to-top-btn-show {
     display: block;
-    z-index: 999;
+    z-index: 11;
     opacity: 1;
   }
 }


### PR DESCRIPTION
- fixes mobile max-width in layout articles (i.e, non-component pages)
- locks scrolling the body when the menu is oepned


I originally applied an overlay similar to our modal:

![borger-overlay](https://user-images.githubusercontent.com/48567940/85779373-61e7e500-b6d8-11ea-8933-0f1ee78edc14.gif)

But was running into weird behavior when scrolling on the overlay rather than the menu. Ideally scrolling anywhere on the page when the menu is open would scroll the menu, but scrolling on the overlay not only would do nothing, but it would seemingly lock the focus to the overlay/body until you actually clicked on the menu.

It also didn't seem to make much sense to have the nav remain at the small size when it's open, so i just made it go fullscreen instead which simplifies the scrolling issues:

![borger-fullscreen](https://user-images.githubusercontent.com/48567940/85786057-bf7f3000-b6de-11ea-95d4-f18aa0c6201c.gif)
