### PR TITLE
add breaking note re: component variables

### DIFF
--- a/docs/components/component-variables/README.md
+++ b/docs/components/component-variables/README.md
@@ -24,9 +24,7 @@ Component variables provide a versioned method for teams to:
 
 Component variables are only available for a core subset of Cedar components, and are distributed in SCSS and LESS format.
 
-Component variables include:
-- Variables for specific properties such as `$cdr-button-base-border-radius`. This is the border-radius value for all Cedar button components
-- Mixins such as `@include cdr-button-base-mixin` which sets many properties on an element. Each component has a `base` mixin which sets properties that apply to all components of that type, as well as `modifier` mixins which only apply to a specific variant of that component
+Component variables include mixins such as `@include cdr-button-base-mixin` which sets many properties on an element. Each component has a `base` mixin which sets properties that apply to all components of that type, as well as `modifier` mixins which only apply to a specific variant of that component
 
 For example, you can import the styling for a Cedar primary button component using a mixin:
 
@@ -36,19 +34,6 @@ For example, you can import the styling for a Cedar primary button component usi
   @include cdr-button-primary-mixin;
 }
 ```
-
-If you only need to apply some styles and not others, you can use individual variables:
-
-```scss
-.your-custom-button-component {
-  border-radius: $cdr-button-base-border-radius;
-  background-color: $cdr-button-primary-background-color;
-}
-```
-
-Teams that are replicating specific Cedar components will want to use the mixins because they are easier to maintain. For example, if a future version of Cedar adds additional properties to an existing mixin, your application will inherit those changes when you update to that version of component variables.
-
-There are some cases where using individual component variables is preferable to using the mixins. For example, if you are using a third party library or component and need to override some values but not others.
 
 
 ### Contract of Intent
@@ -60,8 +45,8 @@ Versioning
   - Outside of the Cedar release schedule, patch versions of component variables will only be issued if a bug is found in the distribution
 
 Semantic naming
-  - Component variables and mixins are semantically named based on the component being styled, how the style is intended to be used, and the CSS property being targeted
-  - Teams must only use component variables and mixins when semantically appropriate
+  - Component variable mixins are semantically named based on the component being styled, how the style is intended to be used, and the CSS property being targeted
+  - Teams must only use component variables when semantically appropriate
 
 <hr />
 
@@ -71,7 +56,7 @@ Semantic naming
   - Your project requires the smallest possible bundle size, and your team is willing to take on the additional maintenance cost of using component variables instead of the Vue.js Cedar components
 
 ### Don't Use When
-  - Do not use the component variables in a non-semantic way. For example, `cdr-button-base-border-radius` should only ever be used to style the border radius of a button element
+  - Do not use the component variables in a non-semantic way. For example, `cdr-button-base-mixin` should only ever be used to style a button element
   - Do not use component variables to publish clones or forks of existing Cedar components. Instead, work with the Cedar team to find a long term solution to support your use case
 
 <hr/>
@@ -86,7 +71,6 @@ The naming structure for component variables and mixins is as follows:
     - Additional modifiers can be stacked on top of that
     - For example, to make a primary large button you would use the variables that have `base`, `primary`, and `large` modifiers
   - **Sub-Element:** Indicates a sub-element of a component. For example, `cdr-input-base-label-color` indicates the color of the label element used inside the input component
-  - **CSS Property:** Describes the CSS property that this variable is applied to. If the property is listed as `mixin`, then  that mixin should be included in this component
   - **State:** Describes the interactive state that this variable is applied to. These correspond to CSS selectors such as `:focus`, `:active`, `:hover`, `:disabled`, etc.
 
 ### Examples
@@ -106,53 +90,45 @@ The naming structure for component variables and mixins is as follows:
         Sub-Element
       </th>
       <th width=240>
-        CSS Property
+        State
       </th>
       <th width=240>
-        State
+        Mixin
       </th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>cdr-</td>
-      <td>button-</td>
-      <td>base-</td>
-      <td></td>
-      <td>border-radius</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>cdr-</td>
-      <td>button-</td>
-      <td>primary-</td>
-      <td></td>
-      <td>background-color-</td>
-      <td>hover</td>
-    </tr>
-    <tr>
-      <td>cdr-</td>
       <td>input-</td>
       <td>base-</td>
-      <td>label-</td>
-      <td>color-</td>
-      <td>disabled</td>
-    </tr>
-    <tr>
-      <td>cdr-</td>
-      <td>input-</td>
-      <td>base-</td>
+      <td></td>
       <td></td>
       <td>mixin</td>
-      <td></td>
     </tr>
     <tr>
       <td>cdr-</td>
       <td>button-</td>
       <td>secondary-</td>
       <td></td>
-      <td>mixin</td>
       <td></td>
+      <td>mixin</td>
+    </tr>
+    <tr>
+      <td>cdr-</td>
+      <td>breadcrumb-</td>
+      <td></td>
+      <td>item-</td>
+      <td>linked-</td>
+      <td>mixin</td>
+    </tr>
+    <tr>
+      <td>cdr-</td>
+      <td>select-</td>
+      <td>base-</td>
+      <td>label-</td>
+      <td>disabled-</td>
+      <td>mixin</td>
     </tr>
   </tbody>
 </cdr-table>

--- a/docs/release-notes/spring-2020/README.md
+++ b/docs/release-notes/spring-2020/README.md
@@ -169,6 +169,10 @@ Internet Explorer 11 has been removed from the REI browser support matrix. Cedar
 
 The space (`cdr-space-...`) and breakpoint (`cdr-breakpoint-...`) tokens in the JS distributions of @rei/cdr-tokens have been made "unitless". Those tokens previously had to be manipulated in order to use them effectively in JavaScript, for example by doing: `CdrSpaceOneX.split('px')[0]`.
 
+### Component Variables Now Export Mixins Only
+
+We have updated our [component variables](https://github.com/rei/rei-cedar-component-variables/) package to export only the mixins for component styles and have excluded the individual variables used within those mixins. Component variables are intended for applying the Cedar component CSS styles in projects which cannot use the Vue components directly, which is satisfied by exporting the mixins. Because the individual styles applied by a mixin might change from release to release it was very difficult to manage and document updates to the individual variables in a way that allowed consumers to stay up to date with Cedar. If you were using individual variables from the component variables package, we recommend you either switch to using the full mixin, replace that variable with the appropriate [Cedar token](../../tokens/all-tokens/) if one exists, or simply hardcoding the value.
+
 ### CdrAccordionGroup Wrapper
 
 CdrAccordion components must now be wrapped inside an instance of CdrAccordionGroup to ensure that accordions meet accessibility requirements. See the [CdrAccordion docs](../../components/accordion/) for more details and examples.


### PR DESCRIPTION
https://github.com/rei/rei-cedar-component-variables/pull/21 documents that we no longer export individual variables. 

Updates the component variables page to remove references to the individual variables

Prooooooobably should have named that package "component-mixins" 🤷‍♀️ 🙊 
