### PR TITLE
Enable computed and methods in sandboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,6 @@ If your examples make use of CdrIcon, you can pass `:load-sprite="true"` in orde
 
 If your examples depend on a `model` being available to the component, you can pass that directly into the object: `<cdr-doc-example-code-pair :sandbox-data="$page.frontmatter.sandboxData" :model="{foo: true}">`
 
+Function objects can be added to the `methods` and `computed` properties of the component as well. Note that `window` functions will not be available within these functions (i.e, setTimeout, console.log, alert): `<cdr-doc-example-code-pair :sandbox-data="$page.frontmatter.sandboxData" :model="{foo: true}" :computed="{foo() {return this.foo ? 'bar' : 'baz';}}" :methods="{blah() {this.foo = false;}}">`
+
 If you need to override the properties of the frontmatter object for a single example, you can do that with an inline `Object.assign`: `<cdr-doc-example-code-pair :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: '.no-box:checked ~ .no-box__content {color: green;}'})">`

--- a/docs/.vuepress/components/cdr-doc-code-snippet.vue
+++ b/docs/.vuepress/components/cdr-doc-code-snippet.vue
@@ -71,6 +71,14 @@ export default {
       type: Object,
       default: () => {}
     },
+    computed: {
+      type: Object,
+      default: () => {}
+    },
+    methods: {
+      type: Object,
+      default: () => {}
+    },
   },
   data: function() {
     return {
@@ -91,7 +99,7 @@ export default {
   },
   computed: {
     sandboxHrefComputed() {
-      return this.sandboxHref || buildSandbox(Object.assign({}, this.sandboxCode, this.sandboxData), this.model);
+      return this.sandboxHref || buildSandbox(Object.assign({}, this.sandboxCode, this.sandboxData), this.model, this.computed, this.methods);
     }
   },
   methods: {

--- a/docs/.vuepress/components/cdr-doc-example-code-pair.vue
+++ b/docs/.vuepress/components/cdr-doc-example-code-pair.vue
@@ -39,7 +39,7 @@
       </div>
     </div>
 
-    <cdr-doc-code-snippet :copy-button="copyButton" :line-numbers="lineNumbers" :max-height="codeMaxHeight" :repository-href="repositoryHref" :sandbox-href="sandboxHref" :sandbox-data="Object.assign({}, sandboxData, {code: sandboxCode, loadSprite})" :model="model" :code-toggle="codeToggle" :hide-code="hideCode">
+    <cdr-doc-code-snippet :copy-button="copyButton" :line-numbers="lineNumbers" :max-height="codeMaxHeight" :repository-href="repositoryHref" :sandbox-href="sandboxHref" :sandbox-data="Object.assign({}, sandboxData, {code: sandboxCode, loadSprite})" :model="model" :computed="computed" :methods="methods" :code-toggle="codeToggle" :hide-code="hideCode">
       <slot :name="slotNames[0]"/> <!-- Only display the code snippet for the first (or only) slot content -->
     </cdr-doc-code-snippet>
   </div>
@@ -125,6 +125,14 @@
         type: Object,
         default: () => {}
       },
+      computed: {
+        type: Object,
+        default: () => {}
+      },
+      methods: {
+        type: Object,
+        default: () => {}
+      },
     },
     data() {
       return {
@@ -157,8 +165,17 @@
       for (const label in this.$slots) {
         const codeNode = this.extractCodeNodeFromVnodeTree(this.$slots[label][0]);
         const templateSource = this.getStoredTemplateSourceForExample(label, codeNode);
-        const m = this.model
-        this.$options.components[`cdr-doc-html-example-${label}-${this.instanceId}`] = { data() { return {...m} }, ...Vue.compile(`<div>${templateSource}</div>`) };
+        const model = this.model;
+        const methods = this.methods;
+        const computed = this.computed;
+        this.$options.components[`cdr-doc-html-example-${label}-${this.instanceId}`] = {
+          data() {
+            return {...model}
+          },
+          methods,
+          computed,
+          ...Vue.compile(`<div>${templateSource}</div>`)
+        };
       }
     },
     methods: {

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -287,6 +287,21 @@ Use `with-background` property in conjunction with the `icon-only` property to m
 
 </cdr-doc-example-code-pair>
 
+## Stateful Button
+
+For buttons that trigger asynchronous actions, use the `click` event and dynamic properties in order to change the label or state of a button.
+
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" :model="{isLoading: false}">
+
+```html
+<cdr-button :disabled="isLoading" @click="isLoading = true">
+  {{isLoading ? 'Loading...' : 'Add to cart'}}
+</cdr-button>
+```
+
+</cdr-doc-example-code-pair>
+
+
 ## Full Width
 
 Displays at full width of its container.

--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -229,14 +229,30 @@ Different sizing for checkboxes.
 
 ## Indeterminate
 
-Displays status for checkbox group by indicating that some of the sub-selections in a list are selected. Provides user with ability to select or unselect all items in the list’s sub-group. To see a functioning example see this [codesandbox](https://codesandbox.io/s/cedar-indeterminate-checkbox-rubkk).
+Displays status for checkbox group by indicating that some of the sub-selections in a list are selected. Provides user with ability to select or unselect all items in the list’s sub-group.
 
-<cdr-doc-example-code-pair repository-href="/src/components/checkbox" :sandbox-data="$page.frontmatter.sandboxData" :model="{ex1: false}">
+<cdr-doc-example-code-pair repository-href="/src/components/checkbox" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrCheckbox, CdrList'})" :model="{selected: ['Cheese'], toppings: ['Cheese', 'Pepperoni', 'Mushroom', 'Peppers'], isIndeterminate: true, allSelected: false }" :methods="{selectAll(isChecked) {if (isChecked) {this.selected = this.toppings.slice();this.allSelected = true; this.isIndeterminate = false;} else { this.selected = []; this.allSelected = false; this.isIndeterminate = false; } }, selectOne() {if (this.selected.length === 0) {this.isIndeterminate = false; this.allSelected = false;} else if (this.selected.length === this.toppings.length) {this.allSelected = true; this.isIndeterminate = false;} else { this.isIndeterminate = true; this.allSelected = false;}}}">
 
 ```html
-<div>
-  <cdr-checkbox v-model="ex1" :indeterminate="!ex1">Indeterminate</cdr-checkbox>
-</div>
+<fieldset>
+  <legend>Choose your toppings</legend>
+   <cdr-checkbox
+     v-model="allSelected"
+     :indeterminate="isIndeterminate"
+     @change="selectAll"
+     aria-controls="toppings"
+   >Select All</cdr-checkbox>
+   <cdr-list role="group" id="toppings" aria-label="Individual toppings" class="cdr-ml-space-one-x">
+     <li v-for="topping in toppings" :key="`checkbox-${topping}`">
+        <cdr-checkbox
+          v-model="selected"
+          :custom-value="topping"
+          name="toppings"
+          @input="selectOne"
+        >{{ topping }}</cdr-checkbox>
+      </li>
+   </cdr-list>
+ </fieldset>
 ```
 
 </cdr-doc-example-code-pair>
@@ -443,7 +459,7 @@ Default checkbox to checked/unchecked state by setting the model in Javascript.
 </script>
 ```
 
-Set the `indeterminate` prop to `true` to generate an indeterminate checkbox, which looks different than the default. This is a visual styling only; it does not include any of the functional aspects of an indeterminate checkbox. To see a functioning example see this [codesandbox](https://codesandbox.io/s/cedar-indeterminate-checkbox-rubkk).
+Set the `indeterminate` prop to `true` to generate an indeterminate checkbox, which looks different than the default. This is a visual styling only; it does not include any of the functional aspects of an indeterminate checkbox. To see a functioning example see the [indeterminate example](#indeterminate).
 
 ```vue
 <template>

--- a/utils/buildSandbox.js
+++ b/utils/buildSandbox.js
@@ -44,6 +44,10 @@ export default function makeMeASandbox(data, model, computed, methods) {
     },
   };
 
+  if (data.loadSprite) {
+    parameters.files['package.json'].content.dependencies['@rei/cedar-icons'] = packageJson.devDependencies['@rei/cedar-icons']
+  }
+
   return `https://codesandbox.io/api/v1/sandboxes/define?parameters=${getParameters(parameters)}`;
 }
 
@@ -86,6 +90,14 @@ function buildContent(data, model, computed, methods) {
 
 function buildScriptTag(data, model, computed, methods) {
   const componentsImport = `import { ${data.components} } from "@rei/cedar/dist/cedar.mjs"; // NOTE: importing from '@rei/cedar/dist/cedar.mjs' to bypass a codesandbox bug. Please import from '@rei/cedar' in your code.`;
+  const spriteString = 'svgSprite, ';
+
+  let stringModel = model ? JSON.stringify(model) : "{}";
+
+  // Insert sprite string into model data
+  if (data.loadSprite) {
+    stringModel = stringModel.slice(0, 1) + spriteString + stringModel.slice(1);
+  }
 
   return `
 ${data.components ? componentsImport : ''}
@@ -97,7 +109,7 @@ export default {
     ${data.components ? data.components : ''}
   },
   data() {
-    return ${model ? JSON.stringify(model) : "{}"}
+    return ${stringModel}
   },
   ${computed ? `computed: ${stringifyFunctionObject(computed)},` : ''}
   ${methods ? `methods: ${stringifyFunctionObject(methods)},` : ''}

--- a/utils/buildSandbox.js
+++ b/utils/buildSandbox.js
@@ -14,7 +14,7 @@ components: { App },
 template: "<App/>"
 });`;
 
-export default function makeMeASandbox(data, model) {
+export default function makeMeASandbox(data, model, computed, methods) {
   // TODO: can we grab the preceding heading to use for name/title?
   const name = "Cedar Example Sandbox";
 
@@ -24,7 +24,7 @@ export default function makeMeASandbox(data, model) {
         content: INDEX_JS,
       },
       'App.vue': {
-        content: buildContent(data, model)
+        content: buildContent(data, model, computed, methods)
       },
       'package.json': {
         content: {
@@ -43,10 +43,6 @@ export default function makeMeASandbox(data, model) {
       }
     },
   };
-
-  if (data.loadSprite) {
-    parameters.files['package.json'].content.dependencies['@rei/cedar-icons'] = packageJson.devDependencies['@rei/cedar-icons']
-  }
 
   return `https://codesandbox.io/api/v1/sandboxes/define?parameters=${getParameters(parameters)}`;
 }
@@ -68,7 +64,7 @@ function buildIndexHtml(title) {
   </html>`;
 }
 
-function buildContent(data, model, fontImport) {
+function buildContent(data, model, computed, methods) {
   return `
 <template>
   <div class="example-root">
@@ -78,7 +74,7 @@ function buildContent(data, model, fontImport) {
 </template>
 
 <script>
-  ${buildScriptTag(data, model)}
+  ${buildScriptTag(data, model, computed, methods)}
 </script>
 
 <style lang="scss">
@@ -88,7 +84,7 @@ function buildContent(data, model, fontImport) {
 </style>`;
 }
 
-function buildScriptTag(data, model) {
+function buildScriptTag(data, model, computed, methods) {
   const componentsImport = `import { ${data.components} } from "@rei/cedar/dist/cedar.mjs"; // NOTE: importing from '@rei/cedar/dist/cedar.mjs' to bypass a codesandbox bug. Please import from '@rei/cedar' in your code.`;
 
   return `
@@ -103,6 +99,14 @@ export default {
   data() {
     return ${model ? JSON.stringify(model) : "{}"}
   },
-  ${data.loadSprite ? 'computed: { svgSprite() { return svgSprite; } }' : ''}
+  ${computed ? `computed: ${stringifyFunctionObject(computed)},` : ''}
+  ${methods ? `methods: ${stringifyFunctionObject(methods)},` : ''}
 };`
+}
+
+function stringifyFunctionObject(obj) {
+  const funcs = Object.keys(obj).map((key) => {
+    return `${key}: ${obj[key].toString()}`
+  })
+  return `{${funcs.join(',\n ')}}`
 }


### PR DESCRIPTION
- adds ability to attach `computed` and `methods` blocks to codesandbox examples
- updates indeterminate checkbox example to make use of this
- adds simple stateful button example