### PR TITLE
merging CTA content

### DIFF
--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -192,8 +192,8 @@
       "text": "See Also",
     },
     {
-      "text": "Call to Action",
-      "href": "../cta/"
+      "text": "Links",
+      "href": "../links/"
     }
   ]
 }
@@ -402,7 +402,7 @@ Call to Action is a stylized link used in campaigns and promotions to encourage 
 
 ## Sizing
 
-Change the button size based on where the button is used. The default size is medium. Small is used for supplemental user actions such as product comparison or filter. Large is used for &quot;Add to cart&quot; on product pages or for a Call to Action.
+Change the button size based on where the button is used. The default size is medium. 
 
 <cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" >
 
@@ -467,10 +467,12 @@ This component has no specific WCAG compliance attributes built into the control
 
 ## The Basics
 
-Buttons sizes are used:
-  - **Small:** Supplemental user actions such as product comparison or filter on product pages
-  - **Medium:** Default size
-  - **Large:** Mobile version for XS grid with full breakpoint width. Also, for &quot;Add to cart&quot; on product pages or for [Call to Action](../cta/) on campaign pages
+Three button sizes are available: Small, Medium, and Large. Medium is the default size. 
+<br />
+Generally, buttons should be sized based on their content and used to convey the importance of actions. 
+  - Use Large buttons for primary page actions
+  - Use Small buttons for supplemental user actions 
+  - For Mobile screens using XS grid, use Large buttons set to full width
 
 <br />
 

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -326,7 +326,7 @@ Displays at full width of its container.
 
 ## Call To Action
 
-TODO: description
+Call to Action is a stylized link used in campaigns and promotions to encourage users to further explore featured products, services or offers. Use CTA when navigating users to a new page. 
 
 <cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, IconCaretRight'})" >
 
@@ -386,7 +386,7 @@ TODO: description
 
 ## Sizing
 
-Change the button size based on where the button is used. The default size is medium. Small is used for supplemental user actions such as product comparison or filter. Large is used for &quot;Add to cart&quot; on product pages or for [Call to Action](../cta/).
+Change the button size based on where the button is used. The default size is medium. Small is used for supplemental user actions such as product comparison or filter. Large is used for &quot;Add to cart&quot; on product pages or for a Call to Action.
 
 <cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" >
 
@@ -401,7 +401,7 @@ Change the button size based on where the button is used. The default size is me
 </cdr-doc-example-code-pair>
 
 ## Accessibility
-Many WCAG requierments are contextual to their implementation.
+Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:
 
 - For icon-only buttons, provide `aria-label` text that describes the button's action
@@ -410,7 +410,19 @@ To ensure that usage of this component complies with accessibility guidelines yo
 - If the button is a toggle button, it has an `aria-pressed` state. When the button is toggled on, the value of this state is true, and when toggled off, the state is false.
 - If the button action indicates a context change, such as move to next step in a wizard or add another search criteria, then it is often appropriate to move focus to the starting point for that action.
 - Apply keyboard interaction patterns as described on [REI universal design and accessibility: Buttons](https://confluence.rei.com/display/accessibility/Buttons)
-
+- For Calls to Action, clearly and concisely describe the link’s destination when the button is clicked or tapped:
+  - For example, if the button text is "Shop now", the `aria-label` might read: "Shop our &lt;specific advertising category&gt; now"
+- Avoid using "click here" or "start here" for Calls to Action. If screen space for text is minimal:
+  - Provide text that can be read by screen readers
+  - Use an inline element for hidden text with the `cdr-sr-only` class
+  ```vue
+  <cdr-cta>
+    Start here <span class="cdr-sr-only">for help finding the proper sleeping bag</span>
+  </cdr-cta>
+  ```
+- Ensure screen readers can find all **Call to Action** buttons on a page by:
+  - Always providing an `href` attribute. Empty `href` attributes are not considered true links
+  - Ensuring that it can be accessed using the keyboard. Avoid manipulating the default tab index
 <br />
 
 This component has no specific WCAG compliance attributes built into the control. It is possibile to define this component as a link or button:
@@ -431,10 +443,10 @@ This component has no specific WCAG compliance attributes built into the control
 - Progressing or regressing a user through a step in a flow
 - Submitting requested information
 - Confirming the completion of a flow or cancelling out of it
+- Use a Call to Action when navigating to another page on the site
 
 ## Don't Use When
 
-- Navigating to another page on a site. Instead use [Call to Action](../cta/)
 - Taking users to a different part within the same page. Instead, use [Links](../links/)
 
 ## The Basics
@@ -474,15 +486,24 @@ When grouping buttons, match button sizes either horizontally or vertically.
 
 <br />
 
+<do-dont :examples="$page.frontmatter.placement" />
+
+<br />
+
 ## Content
 
   - Clearly and concisely label with 1–3 words and fewer than 20 characters, including spaces
-
   - Start with a verb, if possible. Labels must be action-oriented and set expectations for what the user will see next
-
   - Never repeat the context of a label when the context is already clear. For example, for a &quot;Save&quot; button, do not expand to &quot;Save Account Information&quot;
-
   - Use sentence case. Do not use all caps, title caps, or all lowercase
+  
+  <br />
+
+To construct consistent and universal Calls to Action across the site:
+
+- If leading to a Brand, Category, or Activity Landing page, UI text for Call to Action should be **Explore Brand/Category/Activity Name**
+- If leading to a Product Detail page, UI text for Call to Action should be **Shop product name**
+- If leading to a Collection or search result, UI text for Call to Action should be **Shop all Brand/Category/Activity Name**
 
 ### Do / Don't
 
@@ -515,6 +536,12 @@ Apply the following use cases when deciding when to use links as anchors or butt
 | Changing the URL                                                                                    | Opening a modal window                                                               |
 | Causing a browser redraw or refresh                                                                    | Triggering a popup menu                                                              |
 | Supporting internal page jumps                                                                      | Can be disabled with disabled attribute                                              |
+
+### Choosing a Button or Call to Action
+- Use Buttons to trigger interface interactions. 
+- Use CTA to navigate users to a new location/page.
+- Avoid combining a Call to Action with a basic button. Disabling Calls to Action is not semantically supported.
+- Maintain button styling including typographic and sizing for Call to Action. Do not style as a link.
 
 ## Resources
 

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -4,6 +4,22 @@
   "layout_type": "LayoutComponent",
   "summary": "Invoke and communicate an action that will occur",
   "title_metadata": "CdrButton",
+  "ctaPlacement": [
+    {
+      "type": "do",
+      "image": "cta/CTA_placement_do_16-9.png",
+      "ratio": "16-9",
+      "alt": "Image showing proper Call to Action usage",
+      "caption": "use Call to Action to lead users to explore more."
+    },
+    {
+      "type": "dont",
+      "image": "cta/CTA_placement_dont_16-9.png",
+      "ratio": "16-9",
+      "alt": "Image showing proper Call to Action paired with basic button",
+      "caption": "mix Call to Action and basic buttons."
+    }
+  ],
   "vertical": [
     {
       "type": "do",
@@ -326,7 +342,7 @@ Displays at full width of its container.
 
 ## Call To Action
 
-Call to Action is a stylized link used in campaigns and promotions to encourage users to further explore featured products, services or offers. Use CTA when navigating users to a new page. 
+Call to Action is a stylized link used in campaigns and promotions to encourage users to further explore featured products, services or offers. Use CTA when navigating users to a new page. CTA buttons should use the `icon-right` slot, set the `tag` property to `"a"`, and set an `href` to navigate to. 
 
 <cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrButton, IconCaretRight'})" >
 
@@ -486,7 +502,7 @@ When grouping buttons, match button sizes either horizontally or vertically.
 
 <br />
 
-<do-dont :examples="$page.frontmatter.placement" />
+<do-dont :examples="$page.frontmatter.ctaPlacement" />
 
 <br />
 
@@ -496,7 +512,7 @@ When grouping buttons, match button sizes either horizontally or vertically.
   - Start with a verb, if possible. Labels must be action-oriented and set expectations for what the user will see next
   - Never repeat the context of a label when the context is already clear. For example, for a &quot;Save&quot; button, do not expand to &quot;Save Account Information&quot;
   - Use sentence case. Do not use all caps, title caps, or all lowercase
-  
+
   <br />
 
 To construct consistent and universal Calls to Action across the site:
@@ -538,7 +554,7 @@ Apply the following use cases when deciding when to use links as anchors or butt
 | Supporting internal page jumps                                                                      | Can be disabled with disabled attribute                                              |
 
 ### Choosing a Button or Call to Action
-- Use Buttons to trigger interface interactions. 
+- Use Buttons to trigger interface interactions.
 - Use CTA to navigate users to a new location/page.
 - Avoid combining a Call to Action with a basic button. Disabling Calls to Action is not semantically supported.
 - Maintain button styling including typographic and sizing for Call to Action. Do not style as a link.


### PR DESCRIPTION
- updated content to include CTA guidance/info
- on line 489: copied over a do/don't from the CTA docs, not sure if it works just like that or if more needs to be imported? It's the first do/don't here: https://rei.github.io/rei-cedar-docs/components/cta/#do-don-t about not mixing CTA and basic buttons.