### PR TITLE
add doc updates for link-buttons

### DIFF
--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -76,7 +76,19 @@
                 "type": "string",
                 "default": "'#'",
                 "description": "Sets URL to ‘cdr-link’ href property. The tag prop requires value of <a>."
-              }
+              },
+              {
+                "name": "inset",
+                "type": "boolean",
+                "default": "false",
+                "description": "Adds an inset padding to the link that mimics CdrButton sizing and text styling. Should generally be used in conjunction with the `tag` prop set to 'button'. Should not be used for links that are rendered inline with other text. Can be used in conjunction with the `size` prop to render links at small, large, or with responsive sizing."
+              },
+              {
+                "name": "size",
+                "type": "string",
+                "default": "'medium'",
+                "description": "Sets the link size. Only works if the `inset` property is set to `true`. Values can target responsive breakpoints. Breakpoint values are: xs, sm, md, and lg. Examples: { 'small' | 'medium' | 'large' | 'large@sm' }"
+              },
             ],
             "slots": [
               {
@@ -177,9 +189,53 @@ Display standalone link with icon on right.
 
 </cdr-doc-example-code-pair>
 
+
+## Inline Link Button
+
+Use the `tag` prop to render a button that looks like a link. Can be used inline with other text. Should trigger an action rather than navigate to a new page.
+
+<cdr-doc-example-code-pair repository-href="/src/components/link" :sandbox-data="$page.frontmatter.sandboxData" :model="{ count: 0 }">
+
+```html
+  <cdr-text>
+    What do you think?
+    <cdr-link tag="button" @click="count++">
+      Yes
+    </cdr-link>
+    /
+    <cdr-link tag="button" @click="count--">
+      no
+    </cdr-link>
+    {{count}}
+  </cdr-text>
+```
+
+</cdr-doc-example-code-pair>
+
+## Link Button With Inset
+
+Render a button that looks like a link, with inset padding included to provide a larger click target and also match the text styling and sizing options of CdrButton.
+
+<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrLink, CdrButton'})">
+
+```html
+  <div>
+      <cdr-link tag="button" :inset="true">
+        Take Action
+      </cdr-link>
+      <br/><br/>
+      <cdr-link tag="button" :inset="true" size="small">
+        Small Action Link
+      </cdr-link>
+      <cdr-button size="small">Small Action Button</cdr-button>
+  </div>
+```
+
+</cdr-doc-example-code-pair>
+
 ## Accessibility
 
-Many WCAG requirements are contextual to their implementation. 
+Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:
 
 - Always use a `<button>` element for the `tag` prop when there is no `href` attribute that can be applied to the link. Examples are:

--- a/docs/release-notes/summer-2020/README.md
+++ b/docs/release-notes/summer-2020/README.md
@@ -40,7 +40,11 @@ CdrAlert is a simple wrapper component for grouping together form elements with 
 
 ### CdrButton Icon Left and Right Slots
 
-CdrButton has updated with 2 additional slots, `icon-left` and `icon-right`, for rendering icons to the left or right of the button text. Using these slots ensures that the icon is properly spaced within the button and that it's size adjusts with the button size. The original `icon` slot can still be used for rendering `icon-only` buttons.
+CdrButton has updated with 2 additional slots, `icon-left` and `icon-right`, for rendering icons to the left or right of the button text. Using these slots ensures that the icon is properly spaced within the button and that it's size adjusts with the button size. The original `icon` slot can still be used for rendering `icon-only` buttons. See the [CdrButton docs](../../components/buttons/#slots) for more details.
+
+### CdrLink Inset and Size Props
+
+CdrLink has been updated to add new props for `inset` and `size` that allow for rendering a CdrLink with the same text styling and sizing as a CdrButton. These props are intended to be used when the `tag` prop is set to `"button"`. See the [CdrLink docs](../../components/link/#link-button-with-inset) for more details.
 
 ### Media Query Mixins For Breakpoint And Below
 


### PR DESCRIPTION
haven't pulled in the latest cedar changes so the inset/size properties of link button aren't functioning on the doc site yet.

Also added a doc example for inline button links, as we didn't have one previously.