### PR TITLE
icon a11y update

### DIFF
--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -189,8 +189,40 @@ Create a new SVG icon using any valid SVG markup. The wrapping SVG element can b
 ## Accessibility
 
 To ensure that usage of this component complies with accessibility guidelines:
-- If an icon conveys meaning, there must be an `aria-label` that describes the action or idea that the icon represents
-- If an icon is decorative, use an empty `alt` attribute
+- For purely decorative icons, add `aria-hidden="true"` to hide them from screenreaders
+- For a button that only contains an icon, add `aria-hidden="true"` to the icon and an `aria-label` to the button
+- For a link that only contains an icon, add `aria-hidden="true"` to the icon and include screenreader-only text inside of the link using the `cdr-display-sr-only` utility class or mixin.
+- For a button or link that contains text alongside an icon,
+- - If the text provides sufficient description on it's own (for example, "Add to cart" with a cart icon) simply add `aria-hidden="true"` to the icon
+- - If the icon has meaning that is not conveyed by the text, add `aria-hidden="true"` to the icon and use the `cdr-display-sr-only` utility class or mixin to insert screenreader-only text into the button or link in the appropriate place.
+
+
+
+
+- To apply a description to an icon, either:
+- Add aria-hidden="true" to the icon and include screenreader only text alongside it with the description
+
+```
+<icon-whatever aria-hidden="true"/>
+<p class="cdr-display-sr-only">Whatever!</p>
+```
+
+- Pass a `<title>` and `<desc>` into the icon, each with unique ids. Add `role="img"` to root icon and `aria-labelledby="titleid descid"`. If using CdrIcon with custom SVG, make sure title is the first child element.
+
+```
+<!-- Using icon component -->
+<icon-whatever role="img" aria-labelledby="foo bar">
+  <title id="foo">foo</title>
+  <desc id="bar">bar</desc>
+</icon-whatever>
+
+<!-- with custom SVG -->
+<cdr-icon role="img" aria-labelledby="foo bar">
+  <title id="foo">foo</title>
+  <desc id="bar">bar</desc>
+  <svg><path etc./></svg>
+</cdr-icon>
+```
 
 <br/>
 
@@ -201,11 +233,6 @@ Recommendations for writing screen reader text:
 - Avoid technical jargon
 
 <br/>
-
-W3C recommends using `<title>` and `<desc>` elements in SVG for assistive technologies; however these elements have mixed support for screen readers as explained [here](http://haltersweb.github.io/Accessibility/svg.html). Cedar follows these recommendations by:
-- Adding `role=’presentation’` to icons. This hides them from screen readers and causes the icon to be a nested image inside of a button or a link
-- Assigning the attribute `focusable=’false’` to the SVG element
-- Using `aria-label` for buttons or Cedar’s hidden text CSS style for links
 
 <hr>
 

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -188,40 +188,63 @@ Create a new SVG icon using any valid SVG markup. The wrapping SVG element can b
 
 ## Accessibility
 
-To ensure that usage of this component complies with accessibility guidelines:
-- For purely decorative icons, add `aria-hidden="true"` to hide them from screenreaders
-- For a button that only contains an icon, add `aria-hidden="true"` to the icon and an `aria-label` to the button
-- For a link that only contains an icon, add `aria-hidden="true"` to the icon and include screenreader-only text inside of the link using the `cdr-display-sr-only` utility class or mixin.
-- For a button or link that contains text alongside an icon,
-- - If the text provides sufficient description on it's own (for example, "Add to cart" with a cart icon) simply add `aria-hidden="true"` to the icon
-- - If the icon has meaning that is not conveyed by the text, add `aria-hidden="true"` to the icon and use the `cdr-display-sr-only` utility class or mixin to insert screenreader-only text into the button or link in the appropriate place.
+CdrIcon by default adds `aria-hidden="true"` to the root SVG element. If your usage of CdrIcon is purely decorative, or if the icon is already explained by the text surrounding it, then there are no other accessibility steps needed.
 
-
-
-
-- To apply a description to an icon, either:
-- Add aria-hidden="true" to the icon and include screenreader only text alongside it with the description
+- For a button that only contains an icon, add an `aria-label` to the button element describing what the button does.
 
 ```
-<icon-whatever aria-hidden="true"/>
-<p class="cdr-display-sr-only">Whatever!</p>
+<cdr-button :icon-only="true" aria-label="Add to Cart">
+  <icon-cart/>
+</cdr-button>
 ```
 
-- Pass a `<title>` and `<desc>` into the icon, each with unique ids. Add `role="img"` to root icon and `aria-labelledby="titleid descid"`. If using CdrIcon with custom SVG, make sure title is the first child element.
+- For a link that only contains an icon, include screenreader-only text inside of the link element using the `cdr-display-sr-only` utility class or mixin.
 
 ```
-<!-- Using icon component -->
-<icon-whatever role="img" aria-labelledby="foo bar">
-  <title id="foo">foo</title>
-  <desc id="bar">bar</desc>
-</icon-whatever>
+<cdr-link href="/cart">
+  <icon-cart/><span class="cdr-display-sr-only">Go to cart page</span>
+</cdr-link>
+```
 
-<!-- with custom SVG -->
-<cdr-icon role="img" aria-labelledby="foo bar">
-  <title id="foo">foo</title>
-  <desc id="bar">bar</desc>
-  <svg><path etc./></svg>
-</cdr-icon>
+For a button or link that contains text alongside an icon:
+
+- If the text provides sufficient description on it's own (for example, "Add to cart" with a cart icon) there is no need to add any additional accessible text.
+
+```
+<cdr-button>
+  <icon-cart/> Add to Cart
+</cdr-button>
+```
+
+- If the icon has meaning that is not conveyed by the text, add `aria-hidden="true"` to the icon and use the `cdr-display-sr-only` utility class or mixin to insert screenreader-only text into the button or link in the appropriate place.
+
+```
+<cdr-link>
+  <icon-check-lg/><span class="cdr-display-sr-only">Available For</span> Curbside Pickup
+</cdr-link>
+
+
+<cdr-button>
+  <icon-check-lg/><span class="cdr-display-sr-only">Available for</span> Curbside Pickup
+</cdr-button>
+```
+
+For an icon that exists outside of a link, button, or other actionable element, there are 2 ways to apply accessible text to the icon:
+
+- Include screenreader only text alongside the icon describing it's meaning. This is the simplest approach for applying accessible text to an icon and has the best support across browsers and screenreaders.
+
+```
+<icon-virtual-outfitting/>
+<span class="cdr-display-sr-only">Virtual Outfitting</span>
+```
+
+- Pass a `<title>` and `<desc>` into the default slot of the icon component, each with unique ids. Add `role="img"` and `aria-labelledby="titleid descid"` to the icon component, replacing `titleid` and `descid` with the IDs that correspond to the `<title>` and `<desc>` elements. If using CdrIcon with custom SVG, make sure title is the first child element. Note that this approach should be used to visually describe the icon as if it were an image, and should not be used to add contextual description of the icon's meaning.
+
+```
+<icon-ski role="img" aria-labelledby="skiTitle skiDesc">
+  <title id="skiTitle">Skiing</title>
+  <desc id="skiDesc">A stick figure skiing downhill</desc>
+</icon-ski>
 ```
 
 <br/>

--- a/docs/release-notes/summer-2020/README.md
+++ b/docs/release-notes/summer-2020/README.md
@@ -67,7 +67,7 @@ Cedar tokens now includes mixins for the screen-reader only and container utilit
 
 ### Placeholder Selectors for SCSS Mixins
 
-The SCSS distribution of Cedar tokens now includes [placeholder selectors](https://sass-lang.com/documentation/style-rules/placeholder-selectors). If you are using the same mixin multiple times then switching to placeholder selectors will allow SCSS to include that style only once. The placeholder selectors have the same names as their mixin equivalents, but are invoked by using `@extend %mixin-name` rather than `@include mixin-name`: 
+The SCSS distribution of Cedar tokens now includes [placeholder selectors](https://sass-lang.com/documentation/style-rules/placeholder-selectors). If you are using the same mixin multiple times then switching to placeholder selectors will allow SCSS to include that style only once. The placeholder selectors have the same names as their mixin equivalents, but are invoked by using `@extend %mixin-name` rather than `@include mixin-name`:
 
 ```
 .mixin-example {
@@ -80,6 +80,10 @@ The SCSS distribution of Cedar tokens now includes [placeholder selectors](https
 ```
 
 ## Bug Fixes
+
+### CdrIcon a11y Enhancements
+
+We have improved the accessibility of the CdrIcon components by moving the `role="presentation"` attribute from the root element onto the path element. The CdrIcon components now add `aria-hidden="true"` to their root element by default. The meaning of the icon should either be explained by the visible text around it, or by including screenreader-only text using the `cdr-display-sr-only` utility class or mixin. [See the CdrIcon accessibility section](../components/icons#accessibility) for more details.
 
 ## Breaking Changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1082,14 +1082,14 @@
       }
     },
     "@rei/cdr-tokens": {
-      "version": "5.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-5.0.0-alpha.0.tgz",
-      "integrity": "sha512-kdGjlRHbtTOdkwZsczrSVEtxnsYfZ/VIFymkbJmD1iO0Vj2wc2CyR7ysB6CrHxRQ3jAUyRHNh+jGq8EIaOfUnA=="
+      "version": "5.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-5.0.0-alpha.1.tgz",
+      "integrity": "sha512-j4+uxmxSyA9KCPTHZLzq1lTNDbi98cHk4cQn0dPnn9b4iwUKSwRhTAAox+b9Qb4nAWRyIewC+/LCK+Ot9Qcjdw=="
     },
     "@rei/cedar": {
-      "version": "6.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-6.0.0-alpha.0.tgz",
-      "integrity": "sha512-iajGz2ZFZwB1wdxbG9v70HkDy4m+4gWk8iYPICEFpHSX34LBVqHgWQufGNseTHb0qm9OcwvlI8CwavTigDEZGQ==",
+      "version": "6.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-6.0.0-alpha.1.tgz",
+      "integrity": "sha512-BRVM02Lt7l19n2tt08slHTBG/wWiiCaszVyl6Fxvh7N1xHgSD85ThOFzjhG8hYl5CoLI97Q6TwhvSjS4YwiFUg==",
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@babel/runtime-corejs3": "^7.9.2",
@@ -1100,9 +1100,9 @@
       }
     },
     "@rei/cedar-icons": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@rei/cedar-icons/-/cedar-icons-1.6.1.tgz",
-      "integrity": "sha512-IT+PuYLhjNSPbGj6mljUTUVtFdyF04IzhbvNA8+99jG0QTuhSWl7cne2GYjILRh6oGCKOZqlNIuG02af9U7F0Q==",
+      "version": "2.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@rei/cedar-icons/-/cedar-icons-2.0.0-alpha.0.tgz",
+      "integrity": "sha512-Sz6rfMM5qgRqlNbmFTxXcmoB/WXCJTnBuJ/NdXs+HHtF9khxatrN5sggVKQMwbf3BkZ8v86JyGk+EkKD5/c6bg==",
       "dev": true
     },
     "@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@rei/cdr-component-variables": "^3.0.0",
-    "@rei/cedar-icons": "^1.6.1",
+    "@rei/cedar-icons": "^2.0.0-alpha.0",
     "@vuepress/plugin-google-analytics": "^1.4.1",
     "codesandbox": "^2.1.14",
     "cross-env": "^7.0.2",
@@ -39,8 +39,8 @@
   "dependencies": {
     "@babel/runtime": "^7.9.2",
     "@babel/runtime-corejs3": "^7.9.2",
-    "@rei/cdr-tokens": "^5.0.0-alpha.0",
-    "@rei/cedar": "^6.0.0-alpha.0",
+    "@rei/cdr-tokens": "^5.0.0-alpha.1",
+    "@rei/cedar": "^6.0.0-alpha.1",
     "throttle-debounce": "^2.1.0"
   },
   "browserslist": [


### PR DESCRIPTION
based on my research into SVG a11y requirements, this seems like what our recommendations should be.

Wondering if we should just make icons always be aria-hidden, and encourage people to use sr-only instead of doing the title/desc/aria-labelledby stuff. sr-only text with hidden icon seems like it has the most consistent cross-browser/screenreader support. title/desc also seem more intended to describe what the icon looks like rather than what it's purpose is. (for example, on rating stars we dont want a title/desc for every star stating how filled in it is, we really just want sr-only text somewhere that reads out what the rating is)

I think using sr-only everywhere would result in a better screenreader experience, though it may cause "audit trouble" as it might look like we're "hiding" lots of stuff (though IMO we should care more about the user experience than what an audit will spit out)

On the cedar side, I think it makes sense to add aria-hidden by default, and remove it if we detect `aria-label` or `aria-labelledby` being passed into the icon element.