### PR TITLE
Button link shuffle

### DIFF
--- a/docs/.vuepress/theme/styles/examples.scss
+++ b/docs/.vuepress/theme/styles/examples.scss
@@ -70,7 +70,7 @@
 // Update frontmatter sandboxData styleTag in components/grid if changing this.
 
 .custom-card-example {
-  border: 1px solid $cdr-color-border-secondary;
+  border: 1px solid $cdr-color-border-primary;
   padding: $cdr-space-inset-one-x;
   .cdr-card__link {
     &:hover {

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -139,7 +139,7 @@
                 "name": "modifier",
                 "type": "string",
                 "default": "N/A",
-                "description": "Modifies the style variant for this component. Possible values: { 'secondary' }"
+                "description": "Modifies the style variant for this component. Possible values: { 'primary' | 'secondary' | 'sale' | 'dark' | 'link'}"
               }                          
             ],
             "slots": [
@@ -226,6 +226,20 @@ Use `sale` or `dark` for alternative button styling.
   <cdr-button modifier="sale" disabled>Buy now</cdr-button>
   <cdr-button modifier="dark">Add to wish list</cdr-button>
   <cdr-button modifier="dark" disabled>Add to wish list</cdr-button>
+```
+
+</cdr-doc-example-code-pair>
+
+## Link Style
+
+Use `link` modifier to render a button that is styled like a CdrLink. This can be used to create links with the padding and sizing options of a button. Can be used with the `tag` property set to the default `"button"` or `"a"`. For rendering a link inline with text, use [CdrLink](../links). To render a button that behaves like a link, use a [CdrButton with link tag](#button-with-link-tag).
+
+<cdr-doc-example-code-pair repository-href="/src/components/button" :sandbox-data="$page.frontmatter.sandboxData" >
+
+```html
+  <cdr-button modifier="link">Buy now</cdr-button>
+  <br/>
+  <cdr-button modifier="link" tag="a" href="#">View cart</cdr-button>
 ```
 
 </cdr-doc-example-code-pair>

--- a/docs/components/card/README.md
+++ b/docs/components/card/README.md
@@ -121,7 +121,7 @@ Cards should always be used to link to other content, and the `cdr-card__link` u
 Because CdrCard is a simple wrapper component, it's behavior can be customized or overridden in a variety of ways. For example, adding a border, inset padding, or modifying the link behavior.
 
 <cdr-doc-example-code-pair repository-href="/src/components/card"
-:sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: '.custom-card-example {border: 1px solid $cdr-color-border-secondary; padding: $cdr-space-inset-one-x;} .custom-card-example .cdr-card__link {&:hover {color: $cdr-color-text-sale !important;}}'})" >
+:sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: '.custom-card-example {border: 1px solid $cdr-color-border-primary; padding: $cdr-space-inset-one-x;} .custom-card-example .cdr-card__link {&:hover {color: $cdr-color-text-sale !important;}}'})" >
 
 ```html
 <cdr-card class="custom-card-example">

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -77,18 +77,6 @@
                 "default": "'#'",
                 "description": "Sets URL to ‘cdr-link’ href property. The tag prop requires value of <a>."
               },
-              {
-                "name": "inset",
-                "type": "boolean",
-                "default": "false",
-                "description": "Adds an inset padding to the link that mimics CdrButton sizing and text styling. Should generally be used in conjunction with the `tag` prop set to 'button'. Should not be used for links that are rendered inline with other text. Can be used in conjunction with the `size` prop to render links at small, large, or with responsive sizing."
-              },
-              {
-                "name": "size",
-                "type": "string",
-                "default": "'medium'",
-                "description": "Sets the link size. Only works if the `inset` property is set to `true`. Values can target responsive breakpoints. Breakpoint values are: xs, sm, md, and lg. Examples: { 'small' | 'medium' | 'large' | 'large@sm' }"
-              },
             ],
             "slots": [
               {
@@ -194,6 +182,8 @@ Display standalone link with icon on right.
 
 Use the `tag` prop to render a button that looks like a link. Can be used inline with other text. Should trigger an action rather than navigate to a new page.
 
+To visually render a button that behaves like a link, use [a CdrButton with link tag](../buttons#button-with-link-tag). To visually render a link that has the sizing and spacing of a button, use [a CdrButton with link modifier](../buttons#link-style).
+
 <cdr-doc-example-code-pair repository-href="/src/components/link" :sandbox-data="$page.frontmatter.sandboxData" :model="{ count: 0 }">
 
 ```html
@@ -208,27 +198,6 @@ Use the `tag` prop to render a button that looks like a link. Can be used inline
     </cdr-link>
     {{count}}
   </cdr-text>
-```
-
-</cdr-doc-example-code-pair>
-
-## Link Button With Inset
-
-Render a button that looks like a link, with inset padding included to provide a larger click target and also match the text styling and sizing options of CdrButton.
-
-<cdr-doc-example-code-pair :codeMaxHeight= false repository-href="/src/components/link" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrLink, CdrButton'})">
-
-```html
-  <div>
-      <cdr-link tag="button" :inset="true">
-        Take Action
-      </cdr-link>
-      <br/><br/>
-      <cdr-link tag="button" :inset="true" size="small">
-        Small Action Link
-      </cdr-link>
-      <cdr-button size="small">Small Action Button</cdr-button>
-  </div>
 ```
 
 </cdr-doc-example-code-pair>

--- a/docs/release-notes/summer-2020/README.md
+++ b/docs/release-notes/summer-2020/README.md
@@ -42,9 +42,9 @@ CdrAlert is a simple wrapper component for grouping together form elements with 
 
 CdrButton has updated with 2 additional slots, `icon-left` and `icon-right`, for rendering icons to the left or right of the button text. Using these slots ensures that the icon is properly spaced within the button and that it's size adjusts with the button size. The original `icon` slot can still be used for rendering `icon-only` buttons. See the [CdrButton docs](../../components/buttons/#slots) for more details.
 
-### CdrLink Inset and Size Props
+### CdrButton Link Style
 
-CdrLink has been updated to add new props for `inset` and `size` that allow for rendering a CdrLink with the same text styling and sizing as a CdrButton. These props are intended to be used when the `tag` prop is set to `"button"`. See the [CdrLink docs](../../components/link/#link-button-with-inset) for more details.
+CdrButton has been updated to add new modifier: `link`. This is intended to visually style a CdrButton like a link, but with the same size and full-width options of a normal CdrButton. This allows for layouts which use links in the place of or alongside CdrButtons, while also providing an option for links with the bigger click target of a button. CdrLink should still be used for rendering a link inline with other text. See the [CdrButton docs](../../components/buttons/#link-style) for more details.
 
 ### Media Query Mixins For Breakpoint And Below
 
@@ -113,25 +113,29 @@ We have also updated the Cedar icon components with the following breaking chang
 
 ### CdrCta Deprecated and Merged with CdrButton
 
-TODO:
-- made CTA more flexible, insert any icon not just caret-right
-- can now use sm/md/lg CTA
-- more color options for buttons
-migrating CTAs to buttons:
-- CTA should use `tag="a"` and `href=""`, navigate to new page. Button should trigger action on current page
-- CTA brand => primary button, CTA light => secondary button, sale and dark remain the same.
-- elevated is now a prop not a modifier
+The CdrCta component has been deprecated and it's functionality has been merged with CdrButton. The `sale`, `dark`, `elevated`, and right-aligned-icon styles from CdrCta have all been added as options in CdrButton. This was intended to provide more flexibility in constructing calls to action, while also adding additional styling options for rendering CdrButtons.
 
-[See the CdrButton call to action examples](../components/buttons#call-to-action) for more information.
+See the [CdrButton with link tag](../components/buttons#button-with-link-tag) and [CdrButton alternative styles](../components/buttons#alternative-styles) for more information.
+
+In order to update existing instances of CdrCta to instead use CdrButton:
+- Pass the `icon-caret-left` CdrIcon into the `icon-right` slot. Note that this can be replaced with any icon, or the icon can be omitted completely.
+- Update the `ctaStyle` property as needed and pass it into the `modifier` prop of CdrButton
+
+| CdrCta `ctaStyle` | CdrButton `modifier` |
+|--|--|
+| brand | primary |
+| light | secondary |
+| sale | sale |
+| dark | dark |
 
 ```
 // "sale" CdrCta migrated to a CdrButton
-<cdr-cta modifier="sale">Call To Action</cdr-cta>
+<cdr-cta cta-style="sale">Call To Action</cdr-cta>
 <cdr-button modifier="sale" tag="a" href="rei.com">Call To Action <icon-caret-left slot="icon-right"/></cdr-button>
 
-// "elevated brand" CdrCta migrated to a CdrButton
-<cdr-cta modifier="brand elevated">Call To Action</cdr-cta>
-<cdr-button modifier="primary" tag="a" href="rei.com" :elevated="true">Call To Action <icon-caret-left slot="icon-right"/></cdr-button>
+// "brand" CdrCta migrated to a CdrButton
+<cdr-cta cta-style="brand">Call To Action</cdr-cta>
+<cdr-button modifier="primary" tag="a" href="rei.com">Call To Action <icon-caret-left slot="icon-right"/></cdr-button>
 ```
 
 ### CdrCta Tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -1087,16 +1087,35 @@
       "integrity": "sha512-j4+uxmxSyA9KCPTHZLzq1lTNDbi98cHk4cQn0dPnn9b4iwUKSwRhTAAox+b9Qb4nAWRyIewC+/LCK+Ot9Qcjdw=="
     },
     "@rei/cedar": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-BRVM02Lt7l19n2tt08slHTBG/wWiiCaszVyl6Fxvh7N1xHgSD85ThOFzjhG8hYl5CoLI97Q6TwhvSjS4YwiFUg==",
+      "version": "6.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-6.0.0-beta.1.tgz",
+      "integrity": "sha512-3LRDG81dAEeZkiMrfjm5K2yEuA7VpkossnczHvpRrKgq4h5cJ5yEYyX8DuB5fsNZrwumkHtcaNJVHtgr2aeF8g==",
       "requires": {
-        "@babel/runtime": "^7.9.2",
-        "@babel/runtime-corejs3": "^7.9.2",
+        "@babel/runtime": "^7.11.2",
+        "@babel/runtime-corejs3": "^7.11.2",
         "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
-        "clsx": "^1.1.0",
+        "clsx": "^1.1.1",
         "lodash-es": "^4.17.15",
         "tabbable": "^4.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@babel/runtime-corejs3": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+          "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+          "requires": {
+            "core-js-pure": "^3.0.0",
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
       }
     },
     "@rei/cedar-icons": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/runtime": "^7.9.2",
     "@babel/runtime-corejs3": "^7.9.2",
     "@rei/cdr-tokens": "^5.0.0-alpha.1",
-    "@rei/cedar": "^6.0.0-alpha.1",
+    "@rei/cedar": "^6.0.0-beta.1",
     "throttle-debounce": "^2.1.0"
   },
   "browserslist": [


### PR DESCRIPTION
- updates release notes with with cta->button guidance
- adds modifier="link" to button, removes inset/size from link
- update custom card recs