### PR TITLE
update popover/tooltip docs

### DIFF
--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -86,9 +86,9 @@
             ],
             "events": [
               {
-                  "name": "closed",
-                  "arguments": "event",
-                  "description": "$emit event fired when closing the modal."
+                "name": "closed",
+                "arguments": "event",
+                "description": "$emit event fired when closing the modal."
               }
             ]
           }

--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -55,6 +55,11 @@
                 "default": "true",
                 "description": "If set to `true`, popover will attempt to dynamically set it's position to ensure it renders within the visible browser window. If `false` the popover will always render in the provided `position`."
               },
+              {
+                "name": "contentClass",
+                "type": "string",
+                "description": "Adds a custom class to the popover content wrapper. Allows for overriding it's size, styling, etc."
+              },
             ],
             "slots": [
               {

--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -10,7 +10,7 @@
     }
   ],
   "sandboxData": {
-    "components": "CdrPopover, CdrButton, IconInformationFill"
+    "components": "CdrPopover, CdrButton, IconInformationStroke"
   },
 
   "TODO-DO/DONT": [
@@ -38,6 +38,12 @@
           "api": {
             "props": [
               {
+                "name": "id",
+                "type": "string",
+                "required": "true",
+                "description": "Id for the CdrPopover element. Required for accessibility."
+              },
+              {
                 "name": "position",
                 "type": "string",
                 "default": "'up'",
@@ -54,6 +60,22 @@
               {
                 "name": "default",
                 "description": "Slot for CdrPopover content."
+              },
+              {
+                "name": "trigger",
+                "description": "Slot for the element that triggers the popover. Element should be a button and must be the first and only child of this slot. Event handlers are bound to this element automatically."
+              }
+            ],
+            "events": [
+              {
+                "name": "closed",
+                "arguments": "event",
+                "description": "$emit event fired when tooltip is closed."
+              },
+              {
+                "name": "opened",
+                "arguments": "event",
+                "description": "$emit event fired when tooltip is opened."
               }
             ]
           }
@@ -68,19 +90,44 @@
 
 # Overview
 
-CdrPopover is a Popover
+CdrPopover is a wrapper component that accepts a trigger element and popover content. When the trigger element is clicked, the poppver content is rendered. Event bindings between the trigger and the popover are set up automatically. The popover will dynamically update it's position property to ensure that it renders on screen, though this functionality can be disabled by setting autoPosition to false.
 
 <cdr-doc-example-code-pair repository-href="/src/components/CdrPopover"
 :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
-<div> CdrPopover </div>
+<cdr-popover id="popover-example" :position="down">
+  <cdr-button slot="trigger" :icon-only="true" :with-background="true">
+    <icon-information-stroke slot="icon"/>
+  </cdr-button>
+  <div>
+    On click, I provide additional information to the user
+  </div>
+</cdr-popover>
 ```
 </cdr-doc-example-code-pair>
 
 
 ## Accessibility
-TODO
+
+Ensure that usage of this component complies with accessibility guidelines:
+
+- Set an `id` property on the CdrPopover. The component will automatically link that `id` to the trigger element.
+- Content passed in to the `trigger` slot must be an actionable element such as a button.
+- Popover content should ...
+
+This component complies with WCAG guidelines by:
+
+- Adds click handler to trigger element that manages popover state.
+- When opened, moves focus to the first actionable element inside the popover.
+- When closed, restores focus to the last active element before the popover was opened.
+- Dynamically sets `aria-controls` on the trigger element to point to the id of the tooltip.
+- Sets `aria-haspopup="dialog"` on the trigger element.
+- Dynamically sets `aria-expanded` on the popover content.
+- Adds `role="dialog"` to the tooltip content.
+- Popover content is not visible to screen readers when it is closed.
+- Popover can be closed by pressing the close button in the top right corner, by pressing the `esc` key, or by clicking anywhere outside of the popover content.
+
 
 # Guidelines
 
@@ -108,5 +155,8 @@ TODO: Embed do-dont using metadata from frontmatter
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
+## Events
+
+<cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.events" :slots-getting-started-link="false" />
 
 </cdr-doc-table-of-contents-shell>

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -54,6 +54,11 @@
                 "default": "true",
                 "description": "If set to `true`, tooltip will attempt to dynamically set it's position to ensure it renders within the visible browser window. If `false` the tooltip will always render in the provided `position`."
               },
+              {
+                "name": "contentClass",
+                "type": "string",
+                "description": "Adds a custom class to the tooltip content wrapper. Allows for overriding it's size, styling, etc."
+              },
             ],
             "slots": [
               {

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -37,6 +37,12 @@
           "api": {
             "props": [
               {
+                "name": "id",
+                "type": "string",
+                "required": "true",
+                "description": "Id for the CdrTooltip element. Required for accessibility."
+              },
+              {
                 "name": "position",
                 "type": "string",
                 "default": "'up'",
@@ -56,7 +62,19 @@
               },
               {
                 "name": "trigger",
-                "description": "Slot for the element that triggers the tooltip. Event handlers are bound to this element automatically."
+                "description": "Slot for the element that triggers the tooltip. Element should be a button and must be the first and only child of this slot. Event handlers are bound to this element automatically."
+              }
+            ],
+            "events": [
+              {
+                "name": "closed",
+                "arguments": "event",
+                "description": "$emit event fired when tooltip is closed."
+              },
+              {
+                "name": "opened",
+                "arguments": "event",
+                "description": "$emit event fired when tooltip is opened."
               }
             ]
           }
@@ -71,14 +89,16 @@
 
 # Overview
 
-CdrTooltip is a wrapper component that accepts a trigger element and tooltip content. When the trigger element is hovered or focused, the tooltip content is rendered.
+CdrTooltip is a wrapper component that accepts a trigger element and tooltip content. When the trigger element is hovered or focused, the tooltip content is rendered. Event bindings between the trigger and the tooltip are set up automatically. The tooltip will dynamically update it's `position` property to ensure that it renders on screen, though this functionality can be disabled by setting `autoPosition` to `false`.
 
 <cdr-doc-example-code-pair repository-href="/src/components/CdrTooltip"
 :sandbox-data="$page.frontmatter.sandboxData" >
 
 ```html
-<cdr-tooltip :position="down">
-  <cdr-button slot="trigger">X</cdr-button>
+<cdr-tooltip id="tooltip-example" :position="down">
+  <cdr-button slot="trigger">
+    Add To Cart
+  </cdr-button>
   <div>
     On hover or focus, I provide more information about what this button does
   </div>
@@ -86,26 +106,22 @@ CdrTooltip is a wrapper component that accepts a trigger element and tooltip con
 ```
 </cdr-doc-example-code-pair>
 
-## Auto Position
-
-The `autoPosition` property can be used to have the tooltip automatically position itself inside the visible browser window.
-
-<cdr-doc-example-code-pair repository-href="/src/components/CdrTooltip"
-:sandbox-data="$page.frontmatter.sandboxData" >
-
-```html
-<cdr-tooltip :position="left" :autoPosition="true">
-  <cdr-button slot="trigger">X</cdr-button>
-  <div>
-    Using the `autoPosition` property ensures that the tooltip is not rendered offscreen
-  </div>
-</cdr-tooltip>
-```
-</cdr-doc-example-code-pair>
-
-
 ## Accessibility
-TODO
+
+Ensure that usage of this component complies with accessibility guidelines:
+
+- Set an `id` property on the CdrTooltip. The component will automatically link that `id` to the trigger element.
+- Content passed in to the `trigger` slot must be an actionable element such as a button.
+- Tooltip content should directly describe the element that triggers it. For example, providing more information or context about what a button does, or adding a textual description of an icon-only buttton.
+
+This component complies with WCAG guidelines by:
+
+- Adds hover and focus handlers to trigger element to manage tooltip state.
+- Dynamically sets `aria-described-by` on the trigger element to point to the id of the tooltip.
+- Adds `role="tooltip"` to the tooltip content.
+- Tooltip content is visible to screen readers even when it is closed.
+- Tooltip content can be hovered over without the tooltip closing.
+- Tooltip can be closed by removing focus from the trigger, removing hover from the trigger or content, or by pressing the `esc` key.
 
 # Guidelines
 
@@ -133,5 +149,8 @@ TODO: Embed do-dont using metadata from frontmatter
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
+## Events
+
+<cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.events" :slots-getting-started-link="false" />
 
 </cdr-doc-table-of-contents-shell>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1170,6 +1170,20 @@
           "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-5.0.0.tgz",
           "integrity": "sha512-j8i5odAgQi3AuBN1ujVe3X0zi+GTBsUUTXZ4VwFZO7NIuQibsRvoGrrVObCrpFIIcAJZep9K3OpvlLZ0bcyL2A==",
           "dev": true
+        },
+        "@rei/cedar": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-6.1.0.tgz",
+          "integrity": "sha512-LlhhMF8VQdem3CfeM4Au4/TK8IYKKzlqmxIS8Mpu6/9njhnmLlQpvYRFE2mNm15m62UupIkEYuSFy9sp6d2Hrw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.11.2",
+            "@babel/runtime-corejs3": "^7.11.2",
+            "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+            "clsx": "^1.1.1",
+            "lodash-es": "^4.17.15",
+            "tabbable": "^4.0.0"
+          }
         }
       }
     },
@@ -1179,9 +1193,9 @@
       "integrity": "sha512-s899Qb7snKZq+DduCXGhb1DZlKag+eEavhcQiz2ttZuyjSjW62FROvn+EHS8PR7mrneX6+0c0xiA8j3zh6+ryg=="
     },
     "@rei/cedar": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-6.1.0.tgz",
-      "integrity": "sha512-LlhhMF8VQdem3CfeM4Au4/TK8IYKKzlqmxIS8Mpu6/9njhnmLlQpvYRFE2mNm15m62UupIkEYuSFy9sp6d2Hrw==",
+      "version": "7.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-7.0.0-alpha.0.tgz",
+      "integrity": "sha512-8mHre87O9jcTPJ8F3G0/eXXozD3kcAo3zHwYwTYSLGd9hODg+fsjrggvbLYBW8ptyNeikPFIVLl/QDwFaKHIFA==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@babel/runtime-corejs3": "^7.11.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/runtime": "^7.11.2",
     "@babel/runtime-corejs3": "^7.11.2",
     "@rei/cdr-tokens": "^6.0.2",
-    "@rei/cedar": "^6.1.0",
+    "@rei/cedar": "^7.0.0-alpha.0",
     "throttle-debounce": "^2.3.0"
   },
   "browserslist": [


### PR DESCRIPTION
adds docs for opened/closed events, contentClass override prop, accessibility reqs, and improves examples.
