### PR TITLE
move component variables page into doc site

### DIFF
--- a/docs/.vuepress/components/ComponentVariablesPage.vue
+++ b/docs/.vuepress/components/ComponentVariablesPage.vue
@@ -1,0 +1,49 @@
+<script>
+import examplesData from '@rei/cdr-component-variables/dist/docs/examples.json';
+
+export default {
+  name: 'component-variables-page',
+  data() {
+    return {
+      examplesData,
+    };
+  },
+  methods: {
+    formatSCSS(component, example) {
+      return `.${component.name}-${example.name} {\n  ${example.scss.join('\n  ')}\n}`
+    }
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div v-for="component in examplesData" :key="component.name">
+      <h4>{{component.name}}</h4>
+      <table class="comp-vars-examples">
+        <tr><th>Example</th><th>HTML</th><th>SCSS</th></tr>
+        <tr v-for="example in component.examples" :key="`${component.name}-${example.name}`">
+          <td v-html="example.html"/>
+          <td>{{example.html}}</td>
+          <td><pre>{{formatSCSS(component, example)}}</pre></td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+
+@import '../theme/styles/cdr-tokens.scss';
+@import '~@rei/cdr-component-variables/dist/docs/index.scss';
+
+.comp-vars-examples {
+  th {
+    width: 33%;
+  }
+
+  td {
+    background-color: $cdr-color-background-primary;
+  }
+}
+</style>

--- a/docs/components/component-variables/README.md
+++ b/docs/components/component-variables/README.md
@@ -135,9 +135,43 @@ The naming structure for component variables and mixins is as follows:
 
 <br>
 
+## Usage
+
+### Install
+
+The component variables inherit values from the Cedar design tokens, so you will need to install both packages and keep them in sync when updating:
+
+`npm install --save-dev @rei/cdr-tokens @rei/cdr-component-variables`
+
+### Usage
+
+SCSS example:
+```
+@import '@rei/cdr-tokens/dist/scss/cdr-tokens.scss'; /* import the tokens file */
+@import '@rei/cdr-component-variables/dist/scss/index.scss'; /* import the component variables */
+
+.your-button-class {
+  /* use mixins to apply many properties at once */
+  @include cdr-button-base-mixin;
+  @include cdr-button-primary-mixin;
+}
+```
+
+LESS example:
+```
+@import '@rei/cdr-tokens/dist/less/cdr-tokens.less'; /* import the tokens file */
+@import '@rei/cdr-component-variables/dist/less/index.less'; /* import the component variables */
+
+.your-button-class {
+  /* use mixins to apply many properties at once */
+  .cdr-button-base-mixin();
+  .cdr-button-primary-mixin();
+}
+```
+
 ## Resources
 
-For more information on installing and using component variables in your project, view the [README.md on GitHub](https://github.com/rei/rei-cedar-component-variables). Additional examples and a list of supported components are located on the [cedar-component-variables doc site](
+Additional examples and a list of supported components are located on the [cedar-component-variables doc site](
 https://rei.github.io/rei-cedar-component-variables/#/).  There is also a [CodeSandbox](https://codesandbox.io/s/qkwn78nw99) set up for testing out the component variables.
 
 Questions about when to use component variables? Ask the Cedar team in [#cedar-user-support](https://rei.slack.com/messages/CA58YCGN4)

--- a/docs/components/component-variables/README.md
+++ b/docs/components/component-variables/README.md
@@ -35,6 +35,7 @@ For example, you can import the styling for a Cedar primary button component usi
 }
 ```
 
+Test out what you can do with the component variables in this [CodeSandbox](https://codesandbox.io/s/qkwn78nw99).
 
 ### Contract of Intent
 
@@ -143,8 +144,6 @@ The component variables inherit values from the Cedar design tokens, so you will
 
 `npm install --save-dev @rei/cdr-tokens @rei/cdr-component-variables`
 
-### Usage
-
 SCSS example:
 ```
 @import '@rei/cdr-tokens/dist/scss/cdr-tokens.scss'; /* import the tokens file */
@@ -169,10 +168,9 @@ LESS example:
 }
 ```
 
-## Resources
+### Examples
 
-Additional examples and a list of supported components are located on the [cedar-component-variables doc site](
-https://rei.github.io/rei-cedar-component-variables/#/).  There is also a [CodeSandbox](https://codesandbox.io/s/qkwn78nw99) set up for testing out the component variables.
+<component-variables-page />
 
 Questions about when to use component variables? Ask the Cedar team in [#cedar-user-support](https://rei.slack.com/messages/CA58YCGN4)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,6 +1156,7 @@
       "dev": true
     },
     "@rei/cdr-component-variables": {
+<<<<<<< HEAD
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@rei/cdr-component-variables/-/cdr-component-variables-4.0.0.tgz",
       "integrity": "sha512-PX4hOFx+Qe4m2LnZoCBdCf+QTAOIzzbyKi7bCaAptIW4jStZcZgQ8L9UnK/6rDBQESAYz3gLIPMxr0weM8SIbg==",
@@ -1186,6 +1187,12 @@
           }
         }
       }
+=======
+      "version": "5.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-component-variables/-/cdr-component-variables-5.0.0-alpha.0.tgz",
+      "integrity": "sha512-0i7DVE+5EFj5yeuYPPMBxBseQv/Uzioa1uU5punVyFPci6OR01HtkaTWP6isQQsVvL0SBKvLt6O18MixuaMZiw==",
+      "dev": true
+>>>>>>> render component variables examples on docs page
     },
     "@rei/cdr-tokens": {
       "version": "7.0.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-runtime": "^7.11.0",
-    "@rei/cdr-component-variables": "^4.0.0",
+    "@rei/cdr-component-variables": "^5.0.0-alpha.0",
     "@rei/cedar-icons": "^2.1.0",
     "@vuepress/plugin-google-analytics": "^1.5.3",
     "codesandbox": "^2.1.16",


### PR DESCRIPTION
<img width="1036" alt="Screen Shot 2020-10-12 at 11 31 45 AM" src="https://user-images.githubusercontent.com/48567940/95779241-8a432180-0c7e-11eb-88b1-fdc4df10fe6d.png">

takes the output of this PR: https://github.com/rei/rei-cedar-component-variables/pull/30
and renders it on the comp vars doc page.

TODO: 
- Add nav links to each component example
- For any component that has comp vars, add a link to their doc page to this page
- format HTML example code?