### PR TITLE
ensure that hash links navigate correctly

### DIFF
--- a/docs/.vuepress/theme/Layout.vue
+++ b/docs/.vuepress/theme/Layout.vue
@@ -78,7 +78,7 @@ export default {
     window.addEventListener('resize', debounce(250, () => {
       this.sideNavOpen = false;
     }));
-
+    this.navigateToHash();
   },
 
   beforeDestroy () {
@@ -88,10 +88,25 @@ export default {
   watch: {
     $route() {
       this.sideNavOpen = false;
+    },
+    $page(newPage, oldPage) {
+      if (newPage.key !== oldPage.key) {
+        this.navigateToHash();
+      }
     }
   },
 
   methods: {
+    navigateToHash() {
+      if (this.$route.hash) {
+        setTimeout(() => {
+          const element = document.getElementById(this.$route.hash.slice(1));
+          if (element && element.scrollIntoView) {
+            element.scrollIntoView(true);
+          }
+        }, 500);
+      }
+    },
     toggleSideNav() {
       this.sideNavOpen = !this.sideNavOpen;
     },


### PR DESCRIPTION
hash links seem to not work on most of the doc pages if you navigate directly to them, i think because the hash-nav logic runs before the page is actually rendered. vuepress seems to have a number of open issues around hash links as well. 