### PR TITLE
802 bump

### DIFF
--- a/docs/.vuepress/components/cdr-doc-comp-vars.vue
+++ b/docs/.vuepress/components/cdr-doc-comp-vars.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    {{name}} styles are available through the `@rei/cdr-component-variables` package as SCSS and LESS mixins.
+    For projects that cannot make use of the Vue.js component, the {{name}} styles are available through the `@rei/cdr-component-variables` package as SCSS and LESS mixins which can be applied to plain HTML elements.
     See examples on the <a :href="`../component-variables/#${name}`">Component Variables page</a>. <slot/>
   </div>
 </template>

--- a/docs/release-notes/winter-2021/README.md
+++ b/docs/release-notes/winter-2021/README.md
@@ -26,6 +26,12 @@
 
 - If your project depends on any shared component packages (i.e, FEDPACK, FEDCOMP, FEDPAGES), you will want to update those packages to the new version of Cedar before updating your micro-site.
 
+## 8.0.2
+
+### Bug Fixes
+
+- CdrAccordion `unwrap` breakpoint logic has been updated to handle cross browser issues and more closely match the behavior of media queries
+
 ## 8.0.1
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1248,9 +1248,9 @@
       "integrity": "sha512-muxiUXfMbh2IBw7geFxurUnKYQM8WjjWZa+/R1XgfA4vKWAHJL9/IhzhVLwsK6rTqQLmLKjJvW8/0rOP3SXbCg=="
     },
     "@rei/cedar": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-8.0.1.tgz",
-      "integrity": "sha512-Jy0qw3zaSDAx8ySynSYpNIyAUkdywn0kuNAe0JI+sCrSOHjLjEwyCV2MhoCnIuiP2DsIxKEu1jvK1Y38EtFB8g==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-8.0.2.tgz",
+      "integrity": "sha512-iMq5n5uJm9AT4yHYJ/XtEqYIZoIVTxqAd2rJYI3aPyocV8E15nNeoAxaAgMe5qgfbRg/zWK9AyBQVe0HpUe16g==",
       "requires": {
         "@babel/runtime": "^7.12.18",
         "@babel/runtime-corejs3": "^7.12.18",
@@ -9230,8 +9230,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pidtree": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/runtime-corejs3": "^7.13.9",
     "@rei/cdr-component-variables": "^6.0.0",
     "@rei/cdr-tokens": "^8.0.0",
-    "@rei/cedar": "^8.0.1",
+    "@rei/cedar": "^8.0.2",
     "throttle-debounce": "^3.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
- loads cedar 8.0.2
- clarifies the component variables note to emphasize their intended usage (had a CUS question recently where someone thought comp vars was the way to load the CSS for the components)