### PR TITLE
Spring patterns cleanup

### DIFF
--- a/docs/.vuepress/components/ApiPropAlert.vue
+++ b/docs/.vuepress/components/ApiPropAlert.vue
@@ -54,7 +54,7 @@
   }
 
   .api-prop-alert.alert-deprecated {
-    background-color: $cdr-color-background-warning;
+    background-color: $cdr-color-background-message-warning;
     border: 1px solid $cdr-color-border-warning;
 
     .api-prop-alert-icon {

--- a/docs/components/component-variables/README.md
+++ b/docs/components/component-variables/README.md
@@ -170,8 +170,7 @@ LESS example:
 
 ## Examples
 
-<!-- TODO: re-enable after comp vars beta is created -->
-<!-- <component-variables-page /> -->
+<component-variables-page />
 
 Questions about when to use component variables? Ask the Cedar team in [#cedar-user-support](https://rei.slack.com/messages/CA58YCGN4)
 

--- a/docs/components/component-variables/README.md
+++ b/docs/components/component-variables/README.md
@@ -170,7 +170,8 @@ LESS example:
 
 ## Examples
 
-<component-variables-page />
+<!-- TODO: re-enable after comp vars beta is created -->
+<!-- <component-variables-page /> -->
 
 Questions about when to use component variables? Ask the Cedar team in [#cedar-user-support](https://rei.slack.com/messages/CA58YCGN4)
 

--- a/docs/components/form-group/README.md
+++ b/docs/components/form-group/README.md
@@ -53,7 +53,12 @@
                 "default": "false",
                 "description": "Sets the form group to an error state, displays the `error` slot if one is present."
               },
-
+              {
+                "name": "errorRole",
+                "type": "string",
+                "default": "status",
+                "description": "Sets the `role` attribute for the embedded error state messaging."
+              },
               {
                 "name": "disabled",
                 "type": "boolean",

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -163,6 +163,12 @@
                 "description": "Sets the disabled state for the input field and label styling. Also, restricts user input."
               },
               {
+                "name": "numeric",
+                "type": "boolean",
+                "default": "false",
+                "description": "Sets default attributes for an input that should launch a numeric keyboard but is not strictly a 'number' (credit card, security code, postal code, etc.). Should be used in conjunction with the default text type input. An `input` listener can be used to fully restrict input values to numerical characters only"
+              },
+              {
                 "name": "required",
                 "type": "boolean",
                 "default": "false",
@@ -381,6 +387,25 @@ Multiple line input field with expander control in lower right. Note that the pr
   label="Input label"
   placeholder="Placeholder input"
   :rows="4"
+/>
+```
+
+</cdr-doc-example-code-pair>
+
+## Numeric Input
+
+Input field designed to accept numerical input. Launches the numerical keyboard on mobile devices. Does not use the `type="number"` attribute as that is intended for values that are strictly "numbers" such as quantities and not values that contain numerical characters such as credit cards, security codes, month/year values, etc. Can be used in conjunction with [input masking](#input-masking) to handle formatting values like credit cards, or an `input` listener can be used to format or restrict input.
+
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}" :methods="{restrictInput() {this.defaultModel = this.defaultModel.replace(/\D/g, '')}}">
+
+```html
+<cdr-input
+  v-model="defaultModel"
+  label="Numerical input label"
+  placeholder="Placeholder input"
+  optional
+  :numeric="true"
+  @input="restrictInput"
 />
 ```
 

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -181,6 +181,12 @@
                 "description": "Sets the input to an error state, displays the `error` slot if one is present."
               },
               {
+                "name": "errorRole",
+                "type": "string",
+                "default": "status",
+                "description": "Sets the `role` attribute for the embedded error state messaging."
+              },
+              {
                 "name": "background",
                 "type": "string",
                 "default": "primary",

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -51,6 +51,12 @@
                 "description": "Unique id for modal."
               },
               {
+                "name": "role",
+                "type": "string",
+                "default": "dialog",
+                "description": "Overrides the `role` attribute on the modal content element."
+              },
+              {
                 "name": "overlayClass",
                 "type": "string",
                 "default": "N/A",

--- a/docs/components/selects/README.md
+++ b/docs/components/selects/README.md
@@ -116,6 +116,12 @@
                 "description": "Sets the select to an error state, displays the `error` slot if one is present."
               },
               {
+                "name": "errorRole",
+                "type": "string",
+                "default": "status",
+                "description": "Sets the `role` attribute for the embedded error state messaging."
+              },
+              {
                 "name": "size",
                 "type": "number",
                 "default": "medium",

--- a/docs/patterns/forms/README.md
+++ b/docs/patterns/forms/README.md
@@ -190,21 +190,23 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 - To reduce typing effort and reduce errors, ask for the postal code before the City and State fields so they can be automatically populated
 - Size the field to the data expected
 <hr/>
-- Set `type` attribute to "number"
+- Invoke special “numeric” keyboard by passing `:numeric="true"` to CdrInput
 - Dynamically change keyboard type depending on country selected—some countries may have letters in their postal code (eg. United Kingdom)
 - Set `autocomplete` attribute to "postal-code" if no country code is required
+- Use an `input` listener to control the format of the input
+- Use the `maxlength` property to restrict input to the maximum expected length
 
-<!-- TODO: update CdrInput so type="number" dynamically adds pattern/inputmode/novalidate -->
 
-
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :model="{defaultModel: ''}" :methods="{}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :model="{defaultModel: ''}" :methods="{massageInput() {this.defaultModel = this.defaultModel.replace(/\D/g, '')}}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
   label="Postal code"
   autocomplete="postal-code"
-  type="number"
+  :numeric="true"
+  maxlength="5"
+  @input="massageInput"
 >
 </cdr-input>
 ```
@@ -217,7 +219,7 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 - Use the field label “Card number” as charge cards and debit cards are accepted card types alongside credit cards
 - The numerical spacing of the data should match the physical card
 <hr/>
-- Invoke special “numeric” keyboard
+- Invoke special “numeric” keyboard by passing `:numeric="true"` to CdrInput
 - Actively validate the card number field
 - Auto-detect the card type based on the card number
 - Once know, Match the numerical sequence of the field to the physical card
@@ -229,13 +231,13 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 
 ```html
 <cdr-input
-      placeholder="Credit card"
-      v-mask="'#### #### #### ####'"
-      label="Credit card"
-      v-model="defaultModel"
-      autocomplete="cc-number"
-      type="number"
-    >
+  placeholder="Credit card"
+  v-mask="'#### #### #### ####'"
+  label="Credit card"
+  v-model="defaultModel"
+  autocomplete="cc-number"
+  :numeric="true"
+>
 </cdr-input>
 ```
 
@@ -246,19 +248,22 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 - Provide a format hint based on card type
 - Size the field to the data that’s expected using an `input` event listener
 <hr/>
-- Invoke special “numeric” keyboard
+- Invoke special “numeric” keyboard by passing `:numeric="true"` to CdrInput
+- Use an `input` listener to limit input to possible values for the security code
+- Use the `maxlength` attribute to restrict input to the maximum possible length for the security code
 - Assign appropriate autocomplete value: “cc-csc”
 - Dynamically update format hints based on card type
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :model="{defaultModel: ''}" :methods="{limitLength(e) {this.defaultModel = this.defaultModel.substring(0,3)}}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :model="{defaultModel: ''}" :methods="{restrictInput(e) {this.defaultModel = this.defaultModel.replace(/\D/g, '')}}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
   label="Security code"
   autocomplete="cc-csc"
-  type="number"
-  @input="limitLength"
+  :numeric="true"
+  maxlength="3"
+  @input="restrictInput"
 >
   <template slot="helper-text-top">
     Three digit number on the back.
@@ -273,7 +278,7 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 - Use the MM/YY format
 - Size the field to the data that’s expected
 <hr/>
-- Invoke special “numeric” keyboard
+- Invoke special “numeric” keyboard by passing `:numeric="true"` to CdrInput
 - Assign appropriate autocomplete value: “cc-exp”
 - See the [CdrInput documentation](../../components/input#input-masking) for information on setting up an input mask
 
@@ -286,6 +291,7 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
   v-mask="'##/##'"
   placeholder="MM/YY"
   autocomplete="cc-exp"
+  :numeric="true"
 >
 </cdr-input>
 ```
@@ -294,7 +300,7 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 
 ### Country
 
-<!-- TODO: guidance here ??? -->
+- Assign appropriate autocomplete value: “country”
 
 <cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :model="{defaultModel: ''}" :methods="{}">
 
@@ -311,5 +317,29 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 ```
 
 </cdr-doc-example-code-pair>
+
+### Gender
+
+- Never ask for a user’s gender unless absolutely necessary
+- Always provide a reason why the information is required and how it will be used
+- Give the user the option to self-identify
+- Consider adding an additional, optional field for users to further clarify their answer
+- Size the field to the data that’s expected
+<hr/>
+- Assign appropriate autocomplete value: “sex”
+
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :model="{defaultModel: ''}" :methods="{}">
+
+```html
+<cdr-input
+  v-model="defaultModel"
+  label="Gender"
+  autocomplete="sex"
+>
+</cdr-input>
+```
+
+</cdr-doc-example-code-pair>
+
 
 </cdr-doc-table-of-contents-shell>

--- a/docs/release-notes/deprecated/README.md
+++ b/docs/release-notes/deprecated/README.md
@@ -122,6 +122,11 @@
 | cdr-color-border-disabled-darkmode | n/a |
 | cdr-color-border-error-lightmode | cdr-color-border-error |
 | cdr-color-border-selected-lightmode | cdr-color-border-input-default-selected |
+| cdr-color-background-success | cdr-color-background-message-success |
+| cdr-color-background-warning | cdr-color-background-message-warning |
+| cdr-color-background-error | cdr-color-background-message-error |
+| cdr-color-background-info | cdr-color-background-message-info |
+| cdr-color-background-sale | cdr-color-background-message-sale |
 
 
 ### Media Query Mixins
@@ -221,6 +226,27 @@ CdrDataTable has been replaced by [CdrTable](../../components/table). See [the r
 
 The flexbox based CdrRow and CdrCol have been replaced with the CSS grid based [CdrGrid](../../components/grid). See [the release notes](../release-notes/winter-2021/#cdrgrid-component) for more information.
 
+### CdrIcon
+
+| old asset name     | new asset name     |
+|--------------------|--------------------|
+| warning-stroke.svg | error-stroke.svg   |
+| warning-fill.svg   | error-fill.svg     |
+| warning-tri.svg    | warning-fill.svg   |
+
+| old component name | new component name |
+|--------------------|--------------------|
+| IconWarningStroke  | IconErrorStroke    |
+| IconWarningFill    | IconErrorFill      |
+| IconWarningTri     | IconWarningFill    |
+
+
+
+
+## Utility Classes
+
+NOTE: the Cedar utility classes and CdrText modifier have been removed as of Cedar version 9.0.0. These mappings exist purely to guide consumers who may be updating from earlier versions of Cedar. Cedar tokens or plain CSS should be used instead to apply these same styles.
+
 ### CdrText Modifiers
 | Deprecated modifier name | Equivalent modifier names and breakpoints  |
 |--------------------------|--------------------------------------------|
@@ -254,23 +280,6 @@ The flexbox based CdrRow and CdrCol have been replaced with the CSS grid based [
 | | |
 | utility-n00 | utility-sans-n00 |
 | utility-strong-n00 | utility-sans-strong-n00 |
-
-### CdrIcon
-
-| old asset name     | new asset name     |
-|--------------------|--------------------|
-| warning-stroke.svg | error-stroke.svg   |
-| warning-fill.svg   | error-fill.svg     |
-| warning-tri.svg    | warning-fill.svg   |
-
-| old component name | new component name |
-|--------------------|--------------------|
-| IconWarningStroke  | IconErrorStroke    |
-| IconWarningFill    | IconErrorFill      |
-| IconWarningTri     | IconWarningFill    |
-
-
-## Utility Classes
 
 ### Space
 

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -47,31 +47,60 @@ CdrModal now accepts a `role` property that allows for overriding the accessible
 
 TODO: add example to modal page with guidance?
 
+### Brand Color Updates
+
+We have updated the color values of some Cedar tokens to make use of the REI brand color palette. Those tokens are also being used to style the `default` and `sale` version of the CdrButton
+
+We have created a new `cdr-color-background-brand-spruce` color token (TODO: info on usage???)
+
 ## Deprecations
 
-TODO: vue 3 related deprecations?
+TODO: vue 3 related deprecations? scopedSlots -> slots? pagination/breadcrumb/vue-router overrides?
 
 ## Breaking Changes
 
 ### CdrTokens Background Scoping
 
-TODO: -message-
-distingush that these background colors are not tested against for a11y vs. every component
+In order to distinguish generic background colors like primary and secondary from more specific background colors we have re-named several of our background color tokens. This is necessary because the Cedar team exhaustively tests the accessibility of our components against our primary and secondary background colors, but we are unable to guarantee that every state of every Cedar component will be accessible against certain rarer or more specific background types. This scoping also helps clarify that these background color tokens are intended to be used for simple messaging and should not be applied as general background colors.
+
+| Old token name | New token name |
+| cdr-color-background-success | cdr-color-background-message-success |
+| cdr-color-background-warning | cdr-color-background-message-warning |
+| cdr-color-background-error | cdr-color-background-message-error |
+| cdr-color-background-info | cdr-color-background-message-info |
+| cdr-color-background-sale | cdr-color-background-message-sale |
 
 ### CdrModal Aria Describedby
 
-- TODO: fixed typo/casing
+The `aria-describedby` property on CdrModal has been updated to use the correct casing in order to match the default HTML aria attribute
 
 ### CdrInput Default Attributes
 
-- TODO: Updated to default autocorrect/autocapitalize/spellcheck off, can be overridden, etc.
+CdrInput has been updated to set some default attributes that make form inputs behave more consistently across browsers. These attributes can be overridden by passing the same attribute name onto the CdrInput element.
+
+```
+autocorrect="off"
+spellcheck="false"
+autocapitalize="off"
+```
 
 ### Removals
 
 In accordance with our deprecation policy, features that were deprecated in the [Fall 2020 release](../fall-2020/#deprecations) have been removed from Cedar.
 
-- TODO: Utility wipeout - CdrText modifier and Cedar utilities have been removed. Moved to fedpack. Migrate incrementally to tokens. Perf benefits, code quality, etc..
+#### Cedar Utility Classes And CdrText Modifier Have Been Removed
 
-TODO: link to cdr-legacy-utilities fed package, show how to convert cdrtext modifier to utility class
+The Cedar CSS utility classes and CdrText modifier property were intended to allow developers to quickly apply common styling attributes to their applications, as well as to provide parity with some features that were available in Cedar 1. However there are a number of issues with using global CSS utility classes in a micro-site based architecture such as we have at REI:
+
+- In order to use a single utility class, every class in that file must be loaded, which can be quite costly for larger files such as the text or space utilities. This cost comes both in the form of the large CSS asset that must be downloaded, as well as the time it takes the user's browser to parse and render the CSS file.
+- Because each micro-site manages it's own assets independently it is difficult for those larger utility files to be cached and shared across micro-sites without simply loading those utilities on every page. This was not a problem for Cedar 1 as it was loaded on every page already and used primarily in the monolith.
+- Global CSS classes may end up being used in markup that is unrelated to the package that loads it, which can cause unexpected issues when that package is changed. For example, if a shared FEDCOMP component loads the Cedar space utility classes, a micro-site that consumes that component could also end up using those space utilities without loading the utility class file itself. If that shared component is removed or changed, it may break code in the micro-site that depended on that space utility file being loaded. This is an ongoing issue in the removal of Cedar 1 from the monolith and global page template, as often times projects will end up using Cedar 1 classes without realizing where they are being loaded from.
+- Global CSS classes are impossible to version, which makes it very difficult to roll out changes without potentially breaking existing code. A micro-site that imports a specific verison of Cedar can be tested before it is deployed and rolled out independently, but if a global CSS file is altered it will immediately impact every piece of markup that references it.
+
+We have been warning that these files will be deprecated for our past several releases, yet we continue to see new instances of them appear in REI codebases, so we have made the decision to delete them entirely in order to mitigate these ongoing issues with performance and code maintainability.
+
+For teams that need to update to the latest version of Cedar but which use the utility classes or CdrText modifier property too extensively to migrate all at once, we have created a copy of these utility classes in FEDPACK to allow you to incrementally migrate towards @rei/cdr-tokens.
+
+TODO: link to cdr-legacy-utilities fed package, show how to convert to tokens
 
 </cdr-doc-table-of-contents-shell>

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -29,29 +29,48 @@
 
 ## New Features
 
-### Numeric CdrInput
+### Numeric CdrInput Default Attributes
 
-CdrInput type="number" updated to restrict to numeric input, launch numeric keyboard
+CdrInput now accepts a new boolean property called `numeric` which sets some default attributes for inputs that are composed of numerical characters but are not strictly "number" values themselves. The `type="number"` attribute for input elements is designed to be used with actual numbers such as quantities, and does not behave properly with values such as credit cards, security codes, postal codes, or month/year combos.
 
-## Bug Fixes
+If a CdrInput receives either `type="number"` or `:numeric="true"`, it will set default values for the `inputmode` and `pattern` attributes which will force mobile devices to launch a numeric only keyboard. Note that solely using `:numeric="true"` will not restrict input to only numeric characters, see the [CdrInput page](../../components/input#numeric-input)
+
+### Form Element Error Role Property
+
+CdrFormGroup, CdrInput, and CdrSelect now accept an `error-role` property that allows for overriding the accessible `role` attribute on their embedded error state notification.
+
+TODO: add examples to those docs pages witch guidance on when to override that?
+
+### CdrModal Role Property
+
+CdrModal now accepts a `role` property that allows for overriding the accessible `role` property on the modal content element
+
+TODO: add example to modal page with guidance?
 
 ## Deprecations
 
+TODO: vue 3 related deprecations?
+
 ## Breaking Changes
+
+### CdrTokens Background Scoping
+
+TODO: -message-
+distingush that these background colors are not tested against for a11y vs. every component
 
 ### CdrModal Aria Describedby
 
-- fixed typo/casing
+- TODO: fixed typo/casing
 
-### CdrInput Autocorrect
+### CdrInput Default Attributes
 
-- Updated to default autocorrect/autocapitalize/spellcheck off, can be overridden, etc.
+- TODO: Updated to default autocorrect/autocapitalize/spellcheck off, can be overridden, etc.
 
 ### Removals
 
 In accordance with our deprecation policy, features that were deprecated in the [Fall 2020 release](../fall-2020/#deprecations) have been removed from Cedar.
 
-- CdrText modifier and Cedar utilities have been removed. Moved to fedpack. Migrate incrementally to tokens. Perf benefits, code quality, etc..
+- TODO: Utility wipeout - CdrText modifier and Cedar utilities have been removed. Moved to fedpack. Migrate incrementally to tokens. Perf benefits, code quality, etc..
 
 TODO: link to cdr-legacy-utilities fed package, show how to convert cdrtext modifier to utility class
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1238,9 +1238,9 @@
       "dev": true
     },
     "@rei/cdr-component-variables": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-component-variables/-/cdr-component-variables-6.0.0.tgz",
-      "integrity": "sha512-pWcecYcIjLwC2NcVTSdU+vMsa2HIueYNdL1rk+07khxBDAZVbmEqQMJIsKLwvPCH5TCxMZS6mbVoA/0ILHUxKQ=="
+      "version": "7.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-component-variables/-/cdr-component-variables-7.0.0-beta.0.tgz",
+      "integrity": "sha512-htFZ2gLNG/VvF274ayq710wKJGp1kuaNlBpZB1qzBndDttwTq/VQfX2weJIA7Bhykcyq22DCrLmzGbzP9deG+A=="
     },
     "@rei/cdr-tokens": {
       "version": "9.0.0-alpha.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1243,14 +1243,14 @@
       "integrity": "sha512-pWcecYcIjLwC2NcVTSdU+vMsa2HIueYNdL1rk+07khxBDAZVbmEqQMJIsKLwvPCH5TCxMZS6mbVoA/0ILHUxKQ=="
     },
     "@rei/cdr-tokens": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-8.0.0.tgz",
-      "integrity": "sha512-muxiUXfMbh2IBw7geFxurUnKYQM8WjjWZa+/R1XgfA4vKWAHJL9/IhzhVLwsK6rTqQLmLKjJvW8/0rOP3SXbCg=="
+      "version": "9.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-9.0.0-alpha.1.tgz",
+      "integrity": "sha512-feXbIfAGQfa3vXxRZq43CL1+8RVr7GRPUEYR42ZZzkILZazTZUwSiCgslhnC9kqOFplaxmdzh1gWqRbuPlbfgw=="
     },
     "@rei/cedar": {
-      "version": "8.1.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-8.1.0-alpha.0.tgz",
-      "integrity": "sha512-v9whPOF7K8lSLIx63PASuezUMtP5ax85ebYoH22IKq+liVLIKEV/QbmO7+0qmwNIboPtJvDgDr7M9irDwkuqEw==",
+      "version": "9.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-9.0.0-beta.0.tgz",
+      "integrity": "sha512-f2V96l0d3pN+7VwoW7uO3PPgv5zUvGgMgzjTY0bow/zGM30tFj4HIjst3Nu04JRzH1lVoGjgCIxT69uqUGVWWg==",
       "requires": {
         "@babel/runtime": "^7.12.18",
         "@babel/runtime-corejs3": "^7.12.18",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "@babel/runtime": "^7.13.9",
     "@babel/runtime-corejs3": "^7.13.9",
     "@rei/cdr-component-variables": "^6.0.0",
-    "@rei/cdr-tokens": "^8.0.0",
-    "@rei/cedar": "^8.1.0-alpha.0",
+    "@rei/cdr-tokens": "^9.0.0-alpha.1",
+    "@rei/cedar": "^9.0.0-beta.0",
     "throttle-debounce": "^3.0.0"
   },
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@babel/runtime": "^7.13.9",
     "@babel/runtime-corejs3": "^7.13.9",
-    "@rei/cdr-component-variables": "^6.0.0",
+    "@rei/cdr-component-variables": "^7.0.0-beta.0",
     "@rei/cdr-tokens": "^9.0.0-alpha.1",
     "@rei/cedar": "^9.0.0-beta.0",
     "throttle-debounce": "^3.0.0"


### PR DESCRIPTION
 @mhewson probably need to add more info/guidance to spring release notes and formGroup/input/select/modal pages on when to override the role/error-role from this change: https://github.com/rei/rei-cedar/pull/1020/files

- documents error-role prop for forms, role prop for modal
- documents non-number "numeric" type inputs
- pulls in cedar/tokens/comp-vars betas
- improves form patterns examples
- adds TODOs to spring notes to capture stuff to flesh out later