### PR TITLE
delete placeholder content from input/patterns pages

### DIFF
--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -664,8 +664,12 @@ This component has compliance with WCAG guidelines by:
 <do-dont :examples="$page.frontmatter.case" />
 
 <do-dont :examples="$page.frontmatter.punctuation" />
+<!-- TODO: replace with DO use info/helper slots to describe desired input DON'T use placeholder attribute
+<do-dont :examples="$page.frontmatter.placeholder" /> -->
 
-<do-dont :examples="$page.frontmatter.placeholder" />
+<do-dont :examples="$page.frontmatter.required" />
+
+<do-dont :examples="$page.frontmatter.sizes" />
 
 ## Behavior
 
@@ -747,11 +751,6 @@ export default {
 - The default status of an input field is “optional”
 - If the status is set to “required”, the text, “Required” will appear next to the input label
 
-### Do / Don't
-
-<do-dont :examples="$page.frontmatter.required" />
-
-<do-dont :examples="$page.frontmatter.sizes" />
 
 # API
 
@@ -773,59 +772,5 @@ This component will bind any attribute that a [native HTML input element](https:
 ## Component Variables
 
 <cdr-doc-comp-vars name="CdrInput">Note that the <a href="../component-variables/#CdrLabelStandalone">cdr-label-standalone mixins</a> should be used for assembling the label element. </cdr-doc-comp-vars>
-
-## Usage
-
-The **CdrInput** component requires `v-model` to bind the input value to your data model.  You can also use `helper-text` to display additional information below the input.
-
-```vue {3,6,7,8}
-<cdr-input
-  class="demo-input"
-  v-model="inputWithSlots"
-  id="slots-demo"
-  label="Billing address ZIP code">
-  <template slot="helper-text">
-    International customers, if no postal code, enter "NA"
-  </template>
-</cdr-input>
-```
-
-The `aria-label` attribute will be automatically added on compilation based upon what is provided in the `label` prop.
-
-```vue
-<cdr-input
-  class="demo-input"
-  v-model="ariaModel"
-  id="aria-demo"
-  label="First Name">
-</cdr-input>
-```
-
-This will result in the following HTML:
-
-```vue
-<div class="cdr-input-wrap">
-  <input
-    id="aria-demo"
-    type="text"
-    class="cdr-input"
-    aria-label="First Name">
-</div>
-```
-
-Input inherits the `placeholder` attribute for the placeholder text. You can also use the `post-icon` slot for adding an icon.
-
-```vue {4,7,8,9}
-<cdr-input
-  class="demo-input"
-  v-model="inputWithSlots"
-  placeholder="mm/dd/yyyy"
-  id="slots-demo"
-  label="Event Date">
-  <template slot="post-icon">
-    <icon-calendar />
-  </template>
-</cdr-input>
-```
 
 </cdr-doc-table-of-contents-shell>

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -587,6 +587,8 @@ This component has compliance with WCAG guidelines by:
 - Requiring a value for the `label` field
 - When hiding a label, the `aria-label` attribute is set to the `label` value
 
+The HTML `placeholder` attribute should not be used as it creates an inaccessible experience when the placeholder content disappears as soon as the user begins typing into the input field. Instead the `helper-text` or `info` slots should be used to provide any additional information needed to complete the input.
+
 <hr>
 
 # Guidelines

--- a/docs/patterns/forms/README.md
+++ b/docs/patterns/forms/README.md
@@ -231,7 +231,6 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
 
 ```html
 <cdr-input
-  placeholder="Credit card"
   v-mask="'#### #### #### ####'"
   label="Credit card"
   v-model="defaultModel"
@@ -289,7 +288,6 @@ Cedar provides components for the main HTML input elements: [CdrInput](../../com
   v-model="defaultModel"
   label="Input label"
   v-mask="'##/##'"
-  placeholder="MM/YY"
   autocomplete="cc-exp"
   :numeric="true"
 >


### PR DESCRIPTION
- we had duplicate "Do/Don't" sections on the input page so I merged them
- I deleted the whole usage section because it just duplicates stuff that is already in the code sandbox examples, and doesn't cover everything either.
- Comments out the do/don't for placeholder, presumably we should replace this with a `DO use info/helper slots to describe desired input DON'T use placeholder attribute` graphic?