### PR TITLE
wire up background toggle to code examples

### DIFF
--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -203,9 +203,9 @@ Default and standard spacing for checkboxes.
 
 ```html
 <cdr-form-group label="Default label">
-  <cdr-checkbox v-model="ex1">Default checkbox 1</cdr-checkbox>
-  <cdr-checkbox v-model="ex2">Default checkbox 2</cdr-checkbox>
-  <cdr-checkbox v-model="ex3" disabled>Default checkbox 3</cdr-checkbox>
+  <cdr-checkbox v-model="ex1" :background="backgroundColor">Default checkbox 1</cdr-checkbox>
+  <cdr-checkbox v-model="ex2" :background="backgroundColor">Default checkbox 2</cdr-checkbox>
+  <cdr-checkbox v-model="ex3" :background="backgroundColor" disabled>Default checkbox 3</cdr-checkbox>
 </cdr-form-group>
 ```
 
@@ -219,9 +219,9 @@ Different sizing for checkboxes.
 
 ```html
 <cdr-form-group label="Size label">
-  <cdr-checkbox v-model="ex1" size="small">Small checkbox</cdr-checkbox>
-  <cdr-checkbox v-model="ex2" size="medium">Medium checkbox</cdr-checkbox>
-  <cdr-checkbox v-model="ex3" disabled size="large">Large checkbox</cdr-checkbox>
+  <cdr-checkbox v-model="ex1" :background="backgroundColor" size="small">Small checkbox</cdr-checkbox>
+  <cdr-checkbox v-model="ex2" :background="backgroundColor" size="medium">Medium checkbox</cdr-checkbox>
+  <cdr-checkbox v-model="ex3" :background="backgroundColor" disabled size="large">Large checkbox</cdr-checkbox>
 </cdr-form-group>
 ```
 
@@ -235,9 +235,9 @@ Use a custom value in place of true/false checked state.
 
 ```html
 <cdr-form-group label="Custom true/false label">
-  <cdr-checkbox v-model="ex1" true-value="yes" false-value="no">Option 1?</cdr-checkbox> {{this.ex1}}
-  <cdr-checkbox v-model="ex2" true-value="yes" false-value="no">Option 2?</cdr-checkbox> {{this.ex2}}
-  <cdr-checkbox v-model="ex3" true-value="yes" false-value="no">Option 3?</cdr-checkbox> {{this.ex3}}
+  <cdr-checkbox v-model="ex1" :background="backgroundColor" true-value="yes" false-value="no">Option 1?</cdr-checkbox> {{this.ex1}}
+  <cdr-checkbox v-model="ex2" :background="backgroundColor" true-value="yes" false-value="no">Option 2?</cdr-checkbox> {{this.ex2}}
+  <cdr-checkbox v-model="ex3" :background="backgroundColor" true-value="yes" false-value="no">Option 3?</cdr-checkbox> {{this.ex3}}
 </cdr-form-group>
 ```
 
@@ -251,9 +251,9 @@ Use an array as the model to track a list of custom values.
 
 ```html
 <cdr-form-group label="Custom value label">
-  <cdr-checkbox v-model="ex" custom-value="1">1</cdr-checkbox>
-  <cdr-checkbox v-model="ex" custom-value="2">2</cdr-checkbox>
-  <cdr-checkbox v-model="ex" custom-value="3">3</cdr-checkbox>
+  <cdr-checkbox v-model="ex" :background="backgroundColor" custom-value="1">1</cdr-checkbox>
+  <cdr-checkbox v-model="ex" :background="backgroundColor" custom-value="2">2</cdr-checkbox>
+  <cdr-checkbox v-model="ex" :background="backgroundColor" custom-value="3">3</cdr-checkbox>
   {{this.ex}}
 </cdr-form-group>
 ```
@@ -269,9 +269,9 @@ Pass checkbox data into change handlers.
 ```html
 <cdr-form-group label="Handling change label">
   Last edited: {{ this.lastEdited }}
-  <cdr-checkbox v-model="ex" custom-value="1" @change="() => lastEdited = '1'">1</cdr-checkbox>
-  <cdr-checkbox v-model="ex" custom-value="2" @change="() => lastEdited = '2'">2</cdr-checkbox>
-  <cdr-checkbox v-model="ex" custom-value="3" @change="() => lastEdited = '3'">3</cdr-checkbox>
+  <cdr-checkbox v-model="ex" :background="backgroundColor" custom-value="1" @change="() => lastEdited = '1'">1</cdr-checkbox>
+  <cdr-checkbox v-model="ex" :background="backgroundColor" custom-value="2" @change="() => lastEdited = '2'">2</cdr-checkbox>
+  <cdr-checkbox v-model="ex" :background="backgroundColor" custom-value="3" @change="() => lastEdited = '3'">3</cdr-checkbox>
   {{ this.ex }}
 </cdr-form-group>
 ```
@@ -289,6 +289,7 @@ Note the usage of `aria-controls`, `id`, `role`, `aria-label`, and `aria-labelle
 <cdr-form-group label="Choose your toppings">
    <cdr-checkbox
      v-model="allSelected"
+     :background="backgroundColor"
      :indeterminate="isIndeterminate"
      @change="selectAll"
      aria-controls="toppings-input"
@@ -297,6 +298,7 @@ Note the usage of `aria-controls`, `id`, `role`, `aria-label`, and `aria-labelle
      <li v-for="topping in toppings" :key="`checkbox-${topping}`">
         <cdr-checkbox
           v-model="selected"
+          :background="backgroundColor"
           :custom-value="topping"
           name="toppings"
           @input="selectOne"
@@ -319,16 +321,19 @@ Custom styles for checkboxes.
 <cdr-form-group label="Custom checkbox label">
   <cdr-checkbox
     v-model="ex1"
+    :background="backgroundColor"
     modifier="hide-figure"
     input-class="no-box"
     content-class="no-box__content">Custom checkbox 1</cdr-checkbox>
   <cdr-checkbox
     v-model="ex2"
+    :background="backgroundColor"
     modifier="hide-figure"
     input-class="no-box"
     content-class="no-box__content">Custom checkbox 2</cdr-checkbox>
   <cdr-checkbox
     v-model="ex3"
+    :background="backgroundColor"
     modifier="hide-figure"
     input-class="no-box"
     content-class="no-box__content"
@@ -351,16 +356,19 @@ Render a checkbox group with validation and error state
   <cdr-checkbox
     custom-value="A"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >A</cdr-checkbox>
   <cdr-checkbox
     custom-value="B"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >B</cdr-checkbox>
   <cdr-checkbox
     custom-value="C"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >C</cdr-checkbox>
 </cdr-form-group>

--- a/docs/components/form-group/README.md
+++ b/docs/components/form-group/README.md
@@ -120,14 +120,17 @@ Grouping related form controls makes forms more understandable for all users, an
   <cdr-checkbox
     custom-value="A"
     v-model="ex"
+    :background="backgroundColor"
   >A</cdr-checkbox>
   <cdr-checkbox
     custom-value="B"
     v-model="ex"
+    :background="backgroundColor"
   >B</cdr-checkbox>
   <cdr-checkbox
     custom-value="C"
     v-model="ex"
+    :background="backgroundColor"
   >C</cdr-checkbox>
 </cdr-form-group>
 ```
@@ -148,14 +151,17 @@ Rather than passing a `label` prop, the label element can be customized using th
   <cdr-checkbox
     custom-value="A"
     v-model="ex"
+    :background="backgroundColor"
   >A</cdr-checkbox>
   <cdr-checkbox
     custom-value="B"
     v-model="ex"
+    :background="backgroundColor"
   >B</cdr-checkbox>
   <cdr-checkbox
     custom-value="C"
     v-model="ex"
+    :background="backgroundColor"
   >C</cdr-checkbox>
 </cdr-form-group>
 ```
@@ -174,16 +180,19 @@ Render a form group  with validation and error state
   <cdr-checkbox
     custom-value="A"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >A</cdr-checkbox>
   <cdr-checkbox
     custom-value="B"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >B</cdr-checkbox>
   <cdr-checkbox
     custom-value="C"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >C</cdr-checkbox>
 </cdr-form-group>
@@ -203,16 +212,19 @@ Render a form group in a disabled state
   <cdr-checkbox
     custom-value="A"
     v-model="ex"
+    :background="backgroundColor"
     :disabled="true"
   >A</cdr-checkbox>
   <cdr-checkbox
     custom-value="B"
     v-model="ex"
+    :background="backgroundColor"
     :disabled="true"
   >B</cdr-checkbox>
   <cdr-checkbox
     custom-value="C"
     v-model="ex"
+    :background="backgroundColor"
     :disabled="true"
   >C</cdr-checkbox>
 </cdr-form-group>

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -253,16 +253,18 @@
 Basic input field with label.
 
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 />
 <br>
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
   disabled
 />
@@ -275,11 +277,12 @@ Basic input field with label.
 Basic input field with label and required tag.
 
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
   required
 />
@@ -292,11 +295,12 @@ Basic input field with label and required tag.
 Basic input field with label and optional tag.
 
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
   optional
 />
@@ -309,16 +313,18 @@ Basic input field with label and optional tag.
 Change size for the input field. Default size is medium.
 
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 />
 <br>
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
   size="large"
 />
@@ -331,11 +337,12 @@ Change size for the input field. Default size is medium.
 Input field with no label.
 
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
   hideLabel
 />
@@ -350,11 +357,12 @@ Input field with validation that runs on `blur`. Error state is controlled with 
 
 Error messaging will override helper text rendered in the bottom position.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: '', modelError: false}" :methods="{validateInput() {this.modelError = this.defaultModel.length > 4 && 'Error: please enter 4 or less characters'}}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: '', modelError: false}" :methods="{validateInput() {this.modelError = this.defaultModel.length > 4 && 'Error: please enter 4 or less characters'}}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
   :error="modelError"
   @blur="validateInput"
@@ -371,11 +379,12 @@ Error messaging will override helper text rendered in the bottom position.
 
 Multiple line input field with expander control in lower right. Note that the pre-icon, post-icon, and info-action slots will not work properly in multi-line inputs.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
   :rows="4"
 />
@@ -387,11 +396,12 @@ Multiple line input field with expander control in lower right. Note that the pr
 
 Input field designed to accept numerical input. Launches the numerical keyboard on mobile devices. Does not use the `type="number"` attribute as that is intended for values that are strictly "numbers" such as quantities and not values that contain numerical characters such as credit cards, security codes, month/year values, etc. Can be used in conjunction with [input masking](#input-masking) to handle formatting values like credit cards, or an `input` listener can be used to format or restrict input.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}" :methods="{restrictInput() {this.defaultModel = this.defaultModel.replace(/\D/g, '')}}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}" :methods="{restrictInput() {this.defaultModel = this.defaultModel.replace(/\D/g, '')}}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Numerical input label"
   optional
   :numeric="true"
@@ -406,11 +416,12 @@ Input field designed to accept numerical input. Launches the numerical keyboard 
 Input field with link text on right.
 
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, CdrLink'})" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, CdrLink'})" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 >
   <template slot="info">
@@ -425,11 +436,12 @@ Input field with link text on right.
 
 Input field with icon outside the input field on right.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconInformationFill, CdrLink'})" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconInformationFill, CdrLink'})" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 >
   <cdr-link tag="button" slot="info-action">
@@ -446,11 +458,12 @@ Input field with icon outside the input field on right.
 
 Input field with helper or hint text below the input field. If the input is in an error state, the error messaging slot will override this text.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 >
   <template slot="helper-text-bottom">
@@ -465,11 +478,12 @@ Input field with helper or hint text below the input field. If the input is in a
 
 Input field with helper or hint text rendered above the input field.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 >
   <template slot="helper-text-top">
@@ -484,11 +498,12 @@ Input field with helper or hint text rendered above the input field.
 
 Input field with icon inserted into the input field on left. Icon is decorative and not intended for any action.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconLocationPinStroke'})" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconLocationPinStroke'})" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 >
   <IconLocationPinStroke
@@ -505,11 +520,12 @@ Input field with icon inserted into the input field on left. Icon is decorative 
 
 Input field with icon inserted into the input field on right. Icon is decorative and not intended for any action.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconCreditCard'})" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconCreditCard'})" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Input label"
 >
   <IconCreditCard
@@ -526,12 +542,13 @@ Input field with icon inserted into the input field on right. Icon is decorative
 
 Input field with icon buttons inserted to the right. Up to 2 buttons can be passed into the `post-icon` slot. Each button should have the `cdr-input__button` utility class applied to it.
 
-<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconCreditCard, IconXLg, CdrTooltip, CdrButton'})" :backgroundToggle="false" :codeMaxHeight="false"  :model="{defaultModel: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconCreditCard, IconXLg, CdrTooltip, CdrButton'})" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
 ```html
 <div>
   <cdr-input
     v-model="defaultModel"
+    :background="backgroundColor"
     label="Input label"
 
   >
@@ -561,6 +578,7 @@ Input field with icon buttons inserted to the right. Up to 2 buttons can be pass
 
   <cdr-input
     v-model="defaultModel"
+    :background="backgroundColor"
     label="Large Input label"
 
     size="large"

--- a/docs/components/radio/README.md
+++ b/docs/components/radio/README.md
@@ -151,7 +151,7 @@
 ## Default (Medium)
 Default and standard spacing for radio buttons.
 
-<cdr-doc-example-code-pair repository-href="/src/components/radio" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{ex: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/radio" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{ex: ''}">
 
 ```html
 <div>
@@ -164,6 +164,7 @@ Default and standard spacing for radio buttons.
       name="default-example"
       custom-value="ex1"
       v-model="ex"
+      :background="backgroundColor"
     >
       Default radio 1
     </cdr-radio>
@@ -171,6 +172,7 @@ Default and standard spacing for radio buttons.
       name="default-example"
       custom-value="ex2"
       v-model="ex"
+      :background="backgroundColor"
     >
       Default radio 2
     </cdr-radio>
@@ -178,6 +180,7 @@ Default and standard spacing for radio buttons.
       name="default-example"
       :custom-value="{val:'ex3'}"
       v-model="ex"
+      :background="backgroundColor"
       disabled
     >
       Default radio 3
@@ -193,7 +196,7 @@ Default and standard spacing for radio buttons.
 
 Different sizing for radio buttons.
 
-<cdr-doc-example-code-pair repository-href="/src/components/radio" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{ex: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/radio" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{ex: ''}">
 
 ```html
 <div>
@@ -208,6 +211,7 @@ Different sizing for radio buttons.
       name="size-example"
       custom-value="ex1"
       v-model="ex"
+      :background="backgroundColor"
     >
       Small radio
     </cdr-radio>
@@ -215,6 +219,7 @@ Different sizing for radio buttons.
       name="size-example"
       custom-value="ex2"
       v-model="ex"
+      :background="backgroundColor"
     >
       Medium radio
     </cdr-radio>
@@ -223,6 +228,7 @@ Different sizing for radio buttons.
       name="size-example"
       :custom-value="{val:'ex3'}"
       v-model="ex"
+      :background="backgroundColor"
       disabled
     >
       Large radio
@@ -238,7 +244,7 @@ Different sizing for radio buttons.
 
 Custom styles for radio buttons.
 
-<cdr-doc-example-code-pair repository-href="/src/components/radio" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: '.no-box:checked ~ .no-box__content {color: green;}'})" :backgroundToggle="false" :codeMaxHeight="false" class="custom-radio-example" :model="{ex: ''}">
+<cdr-doc-example-code-pair repository-href="/src/components/radio" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {styleTag: '.no-box:checked ~ .no-box__content {color: green;}'})" :codeMaxHeight="false" class="custom-radio-example" :model="{ex: ''}">
 
 ```html
 <div>
@@ -251,6 +257,7 @@ Custom styles for radio buttons.
       name="custom-example"
       custom-value="ex1"
       v-model="ex"
+      :background="backgroundColor"
       modifier="hide-figure"
       input-class="no-box"
       content-class="no-box__content"
@@ -261,6 +268,7 @@ Custom styles for radio buttons.
       name="custom-example"
       custom-value="ex2"
       v-model="ex"
+      :background="backgroundColor"
       modifier="hide-figure"
       input-class="no-box"
       content-class="no-box__content"
@@ -271,6 +279,7 @@ Custom styles for radio buttons.
       name="custom-example"
       :custom-value="{val:'ex3'}"
       v-model="ex"
+      :background="backgroundColor"
       modifier="hide-figure"
       input-class="no-box"
       content-class="no-box__content"
@@ -299,18 +308,21 @@ Render a radio group with validation and error state
     name="letter"
     custom-value="A"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >A</cdr-radio>
   <cdr-radio
     name="letter"
     custom-value="B"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >B</cdr-radio>
   <cdr-radio
     name="letter"
     custom-value="C"
     v-model="ex"
+    :background="backgroundColor"
     @input="validate"
   >C</cdr-radio>
 </cdr-form-group>

--- a/docs/components/selects/README.md
+++ b/docs/components/selects/README.md
@@ -195,11 +195,12 @@
 Basic select control with label.
 
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
 
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -207,6 +208,7 @@ Basic select control with label.
 <br>
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -221,11 +223,12 @@ Basic select control with label.
 
 Basic select control with no label.
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
 
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -234,6 +237,7 @@ Basic select control with no label.
 <br>
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -249,11 +253,12 @@ Basic select control with no label.
 
 Select control with link text on right.
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrSelect, CdrLink'})" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrSelect, CdrLink'})" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
 
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -270,6 +275,7 @@ Select control with link text on right.
 <br>
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -293,11 +299,12 @@ Select control with link text on right.
 
 Select control with icon outside select field on right.
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrSelect, IconInformationFill, CdrButton'})" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrSelect, IconInformationFill, CdrButton'})" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
 
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -317,11 +324,12 @@ Select control with icon outside select field on right.
 
 Input field with helper or hint text below the input field.
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: '', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}">
 
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -333,6 +341,7 @@ Input field with helper or hint text below the input field.
 <br>
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -351,11 +360,12 @@ Input field with helper or hint text below the input field.
 
 Error prop and slot can be used to render the select in an error state
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: '', modelError: 'Please make a selection', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}" :methods="{validate() {this.modelError = !this.defaultModel.length && 'Please make a selection'}}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: '', modelError: 'Please make a selection', defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D']}" :methods="{validate() {this.modelError = !this.defaultModel.length && 'Please make a selection'}}">
 
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   prompt="Prompt text"
   :options="defaultOptions"
@@ -371,13 +381,14 @@ Error prop and slot can be used to render the select in an error state
 
 CdrSelect can be rendered as a multi-select by passing the native HTML select `multiple` attribute. The `multipleSize` prop can be used to control the height of the multi-select.
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: [], defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D', 'Option E', 'Option F']}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: [], defaultOptions: ['Option A', 'Option B', 'Option C', 'Option D', 'Option E', 'Option F']}">
 
 ```html
 default multi-select:
 <br>
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   :options="defaultOptions"
   multiple
@@ -387,6 +398,7 @@ With multipleSize:
 <br>
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
   :options="defaultOptions"
   multiple
@@ -400,11 +412,12 @@ With multipleSize:
 
 CdrSelect can be rendered with nested options using the `optgroup` tag.
 
-<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" :model="{defaultModel: []}">
+<cdr-doc-example-code-pair repository-href="/src/components/select" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: []}">
 
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Select label"
 >
   <optgroup label="bread">

--- a/docs/patterns/forms/README.md
+++ b/docs/patterns/forms/README.md
@@ -51,6 +51,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Email"
   type="email"
   autocomplete="email"
@@ -78,6 +79,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Phone number"
   type="tel"
   v-mask="'(###) ###-####'"
@@ -108,6 +110,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 <div>
   <cdr-input
     v-model="defaultModel"
+    :background="backgroundColor"
     label="Full name"
     autocomplete="name"
     @blur="validate"
@@ -118,6 +121,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   <cdr-input
     v-if="showPreferredName"
     v-model="preferredModel"
+    :background="backgroundColor"
     label="Preferred name"
     autocomplete="name"
     :optional="true"
@@ -146,6 +150,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 <div>
   <cdr-input
     v-model="lineOne"
+    :background="backgroundColor"
     label="Street address"
     autocomplete="address-line1"
     :required="true"
@@ -155,6 +160,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   <cdr-input
     v-if="showLineTwo"
     v-model="lineTwo"
+    :background="backgroundColor"
     label="Adddress line 2"
     autocomplete="address-level2"
     :optional="true"
@@ -183,6 +189,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Postal code"
   autocomplete="postal-code"
   :numeric="true"
@@ -216,6 +223,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   v-mask="'#### #### #### ####'"
   label="Card number"
   v-model="defaultModel"
+  :background="backgroundColor"
   autocomplete="cc-number"
   :numeric="true"
 >
@@ -240,6 +248,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Security code"
   autocomplete="cc-csc"
   :numeric="true"
@@ -269,6 +278,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 ```html
 <cdr-input
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Valid thru"
   v-mask="'##/##'"
   autocomplete="cc-exp"
@@ -292,6 +302,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Country"
   autocomplete="country"
 >
@@ -318,6 +329,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 ```html
 <cdr-select
   v-model="defaultModel"
+  :background="backgroundColor"
   label="Gender"
   :required="true"
   autocomplete="sex"
@@ -340,6 +352,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
 <cdr-input
   v-if="showDescribe"
   v-model="describeModel"
+  :background="backgroundColor"
   label="Please describe"
   :required="true"
   autocomplete="sex"


### PR DESCRIPTION
- fixes backgroundToggle logic for code examples (was still halfway set up for the old "light/dark" theming pattern we had going on)
- The active backgroundColor now is available to component code to use
- Updates form patterns and form component doc pages to use the background prop.