### PR TITLE
Vue 3 deprecations

### DIFF
--- a/docs/.vuepress/components/ApiSlot.vue
+++ b/docs/.vuepress/components/ApiSlot.vue
@@ -8,6 +8,12 @@
       >
         <cdr-col
           span="12"
+          v-if="apiSlot.alert"
+        >
+          <api-prop-alert :alert="apiSlot.alert" />
+        </cdr-col>
+        <cdr-col
+          span="12"
         >
           <div>
             <p :aria-labelledby="'slotName' + index" class="slot-name">{{ apiSlot.name }}</p>

--- a/docs/.vuepress/theme/NavLinks.vue
+++ b/docs/.vuepress/theme/NavLinks.vue
@@ -11,7 +11,7 @@
         :opened="navGroup[index]"
         @accordion-toggle="navToggle(index)"
       >
-        <template slot="label">
+        <template v-slot:label>
           {{ item.text }}
         </template>
         <ul class="nav-dropdown cdr-doc-side-navigation__child-links">

--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -135,7 +135,7 @@ Section borders expand to full width of container.
     :opened="default1"
     @accordion-toggle="default1 = !default1"
   >
-    <template slot="label">
+    <template v-slot:label>
       How do I find my member number?
     </template>
     <cdr-text tag="p">
@@ -149,7 +149,7 @@ Section borders expand to full width of container.
     :opened="default2"
     @accordion-toggle="default2 = !default2"  
   >
-    <template slot="label">
+    <template v-slot:label>
       Does every member get an Annual Dividend?
     </template>
     <cdr-text tag="p">
@@ -164,7 +164,7 @@ Section borders expand to full width of container.
     :opened="default3"
     @accordion-toggle="default3 = !default3"
   >
-    <template slot="label">
+    <template v-slot:label>
       When does my dividend expire?
     </template>
     <cdr-text tag="p">
@@ -192,7 +192,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
     :opened="compact1"
     @accordion-toggle="compact1 = !compact1"
   >
-    <template slot="label">
+    <template v-slot:label>
       Why buy used gear?
     </template>
     <cdr-text tag="p">
@@ -207,7 +207,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
     :opened="compact2"
     @accordion-toggle="compact2 = !compact2"
   >
-    <template slot="label">
+    <template v-slot:label>
       What's your cancellation policy?
     </template>
     <cdr-text tag="p">
@@ -222,7 +222,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
     :opened="compact3"
     @accordion-toggle="compact3 = !compact3"
   >
-    <template slot="label">
+    <template v-slot:label>
       When will my order arrive?
     </template>
     <cdr-text tag="p">
@@ -250,7 +250,7 @@ Border aligns to the title text and expand/collapse icon.
     :opened="borderAligned1"
     @accordion-toggle="borderAligned1 = !borderAligned1"
   >
-    <template slot="label">
+    <template v-slot:label>
       How long have you been in business?
     </template>
     <cdr-text tag="p">
@@ -266,7 +266,7 @@ Border aligns to the title text and expand/collapse icon.
     :opened="borderAligned2"
     @accordion-toggle="borderAligned2 = !borderAligned2"
   >
-    <template slot="label">
+    <template v-slot:label>
       What kinds of trips are offered?
     </template>
     <cdr-text tag="p">
@@ -283,7 +283,7 @@ Border aligns to the title text and expand/collapse icon.
     :opened="borderAligned3"
     @accordion-toggle="borderAligned3 = !borderAligned3"
   >
-    <template slot="label">
+    <template v-slot:label>
       How do I know what each trip is like?
     </template>
     <cdr-text tag="p">
@@ -311,7 +311,7 @@ The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion
     :opened="unwrap1"
     @accordion-toggle="unwrap1 = !unwrap1"
   >
-    <template slot="label">
+    <template v-slot:label>
       How do I find my member number?
     </template>
     <cdr-text tag="p">
@@ -325,7 +325,7 @@ The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion
     :opened="unwrap2"
     @accordion-toggle="unwrap2 = !unwrap2"  
   >
-    <template slot="label">
+    <template v-slot:label>
       Does every member get an Annual Dividend?
     </template>
     <cdr-text tag="p">
@@ -340,7 +340,7 @@ The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion
     :opened="unwrap3"
     @accordion-toggle="unwrap3 = !unwrap3"
   >
-    <template slot="label">
+    <template v-slot:label>
       When does my dividend expire?
     </template>
     <cdr-text tag="p">
@@ -460,7 +460,7 @@ CdrAccordion emits an event when its button is clicked. Use an event listener to
     :opened="opened"
     @accordion-toggle="opened = !opened"
   >
-    <template slot="label">
+    <template v-slot:label>
       Click me to show content!
     </template>
       This content is revealed when the accordion is opened.
@@ -496,7 +496,7 @@ Creating groups can be useful if, for instance, you wanted to close the other ac
     :key="item.id"
     @accordion-toggle="updateGroup(index)"
   >
-    <template slot="label">
+    <template v-slot:label>
       {{ item.label }}
     </template>
     {{ item.content }}

--- a/docs/components/breadcrumb/README.md
+++ b/docs/components/breadcrumb/README.md
@@ -177,33 +177,6 @@ Can be used to override the default link navigation behavior inside a breadcrumb
 ```
 </cdr-doc-example-code-pair>
 
-<!--
-TODO: mark as deprecated? just delete?
- ## Link Scoped Slot
-
-Can be used to override the default links rendered in the breadcrumb. Useful for integrating with client-side routing, as a `router-link` can be rendered instead of a plain `a` tag. The `slot-scope` exposed includes:
-
-- `class`: CSS class to be applied to your override element to match the breadcrumb styling
-- `href`: the path that the link points to
-- `content`: the text content of that link
-
-<cdr-doc-example-code-pair repository-href="/src/components/breadcrumb" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight= false>
-
-```html
-<cdr-breadcrumb :items="[
-  {item:{url:'/snowboarding', name: 'Snowboarding'}},
-  {item:{url:'/snowboarding/clothing', name: ' Clothing'}}
-]">
-  <template
-    v-slot:link="link"
-  >
-    <div :class="link.class" @click="console.log(link.href)">
-      {{ link.content }}
-    </div>
-  </template>
-</cdr-breadcrumb>
-```
-</cdr-doc-example-code-pair> -->
 
 ## Accessibility
 
@@ -301,6 +274,10 @@ Truncate breadcrumbs left to right to show the final two links in the trail, so 
 ## Scoped Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.scopedSlots" />
+
+## Events
+
+<cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
 
 ## Component Variables

--- a/docs/components/breadcrumb/README.md
+++ b/docs/components/breadcrumb/README.md
@@ -94,9 +94,20 @@
             "scopedSlots": [
               {
                 "name": "link",
-                "description": "Scoped slot used to override the default links used in the breadcrumb. Useful for integrating with client-side routing. The slot scope exposes the following attributes: class, href, and content."
+                "description": "Scoped slot used to override the default links used in the breadcrumb. Useful for integrating with client-side routing. The slot scope exposes the following attributes: class, href, and content.",
+                "alert": {
+                  "type": "deprecated",
+                  "description": "The link scoped slot has been deprecated, use an event handler on the `navigate` event instead to customize link navigation behavior"
+                },
               }
             ],
+            "events": [
+              {
+                  "name": "navigate",
+                  "arguments": "breadcrumb, event",
+                  "description": "$emit event fired when a breadcrumb item is clicked. `e.preventDefault()` may be used to override the default link navigation."
+              }
+            ]
           }
         }
       ],
@@ -146,8 +157,29 @@ Complete breadcrumb string with all items visible.
 
 </cdr-doc-example-code-pair>
 
+## Custom Navigation
 
-## Link Scoped Slot
+Can be used to override the default link navigation behavior inside a breadcrumb.
+
+<cdr-doc-example-code-pair repository-href="/src/components/breadcrumb" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :methods="{handleNavigation(bc, e) {e.preventDefault(); this.lastClicked = bc.item.name}}" :model="{lastClicked: ''}">
+
+```html
+<div>
+  <cdr-breadcrumb :items="[
+    {item:{url:'/snowboarding', name: 'Snowboarding'}},
+    {item:{url:'/snowboarding/clothing', name: ' Clothing'}}
+  ]"
+  @navigate="handleNavigation"
+  />
+
+  Last Clicked: {{ lastClicked }}
+</div>
+```
+</cdr-doc-example-code-pair>
+
+<!--
+TODO: mark as deprecated? just delete?
+ ## Link Scoped Slot
 
 Can be used to override the default links rendered in the breadcrumb. Useful for integrating with client-side routing, as a `router-link` can be rendered instead of a plain `a` tag. The `slot-scope` exposed includes:
 
@@ -163,8 +195,7 @@ Can be used to override the default links rendered in the breadcrumb. Useful for
   {item:{url:'/snowboarding/clothing', name: ' Clothing'}}
 ]">
   <template
-    slot="link"
-    slot-scope="link"
+    v-slot:link="link"
   >
     <div :class="link.class" @click="console.log(link.href)">
       {{ link.content }}
@@ -172,7 +203,7 @@ Can be used to override the default links rendered in the breadcrumb. Useful for
   </template>
 </cdr-breadcrumb>
 ```
-</cdr-doc-example-code-pair>
+</cdr-doc-example-code-pair> -->
 
 ## Accessibility
 

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -255,20 +255,22 @@ Pair an icon with text to improve recognition about an object or action.
     <cdr-button
       modifier="secondary"
     >
-      <IconPlayStroke
-        slot="icon-left"
-        inherit-color
-      />
+      <template v-slot:icon-left>
+        <icon-play-stroke
+          inherit-color
+        />
+      </template>
       Play video
     </cdr-button>
     <cdr-button
       modifier="secondary"
       disabled
     >
-      <IconPlayStroke
-        slot="icon-left"
-        inherit-color
-      />
+      <template v-slot:icon-left>
+        <icon-play-stroke
+          inherit-color
+        />
+      </template>
       Play video
     </cdr-button>
   </div>
@@ -288,10 +290,9 @@ Use icons to visually communicate an object or action in a limited space. Includ
       :icon-only="true"
       aria-label="More information about icon"
     >
-      <IconQuestionFill
-        slot="icon"
-        inherit-color
-      />
+      <template v-slot:icon>
+        <icon-question-fill inherit-color />
+      </template>
     </cdr-button>
   </div>
 ```
@@ -311,9 +312,9 @@ Use `with-background` property in conjunction with the `icon-only` property to m
       :with-background="true"
       aria-label="More information about icon"
     >
-      <IconAccountProfile
-        slot="icon"
-      />
+      <template v-slot:icon>
+        <icon-account-profile />
+      </template>
     </cdr-button>
   </div>
 ```
@@ -540,117 +541,13 @@ This component will bind any attribute that a [native HTML button element](https
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
+## Events
+
+<cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
+
+
 ## Component Variables
 
 <cdr-doc-comp-vars name="CdrButton"/>
-
-## Usage
-
-### Size Prop
-
-The below example uses the `size` prop to set a default and responsive size. This button’s size is small, but it will become a large button at the `xs` and `sm` breakpoints.
-
-```vue{3}
-<template>
-  <cdr-button
-    size="small large@xs large@sm"
-  >
-    Add to cart
-  </cdr-button>
-</template>
-```
-
-### Modifiers
-
-The following variants are available to the `cdr-button` modifier attribute:
-
-| Value | Description            |
-|:------|:-----------------------|
-| 'primary' | Sets the primary style for the button |
-| 'secondary' | Sets the secondary style for the button |
-| 'sale' | Sets the sale style for the button |
-| 'dark' | Sets the dark style for the button |
-
-
-### Click Actions
-
-Use an `@click` event handler to attach custom actions and event handling.
-
-```vue{3}
-<template>
-  <cdr-button
-    @click="greet"
-  >
-    Greet
-  </cdr-button>
-</template>
-
-<script>
-export default {
-  ...
-  methods: {
-    greet() {
-      console.log(‘Hello there’);
-    }
-  }
-}
-</script>
-```
-
-## Composing with Icons
-
-**CdrButton** component can be used with the icon component from the **CdrIcon** package.
-
-### Text and Icon
-
-To scale Cedar icons appropriately, use the `icon-left` or `icon-right` slots to ensure the proper styles are applied. The `size` prop scales both the icon and the button.
-
-In the below example, a "Download" button is rendered as a button with icon and text using and inline Cedar icon component.
-
-```vue{5}
-<template>
-  <cdr-button>
-    <IconDownload
-      slot="icon-left"
-    />
-    Download
-  </cdr-button>
-</template>
-
-<script>
-import { CdrButton, IconDownload } from '@rei/cedar';
-export default {
-  ...
-  components: {
-     CdrButton,
-     IconDownload,  
-  }
-}
-</script>
-```
-
-### Icon Only
-
-Use the following props to modify `cdr-button`:
-
-- Default slot must be empty. If text is present in default slot, the text will render  
-- `size` prop is disabled when `icon-only` prop is true
-- `with-background` can be used to add a border and background to the icon-only button, ensuring it is more visible on darker backgrounds
-- Add `aria-label` text to describe the button’s action when clicked or tapped
-
-```vue{3,4,5}
-<template>
-  <cdr-button
-    :icon-only="true"
-    :with-background="true"
-    aria-label="Complete this step"
-  >
-    <icon-check-lg
-      slot="icon"
-    />
-  </cdr-button>
-</template>
-```
-
 
 </cdr-doc-table-of-contents-shell>

--- a/docs/components/chips/README.md
+++ b/docs/components/chips/README.md
@@ -210,7 +210,7 @@
 <cdr-doc-table-of-contents-shell>
 
 # Overview
-Chips are compact elements that represent a selection, attribute, or dynamic action. 
+Chips are compact elements that represent a selection, attribute, or dynamic action.
 
 ## Default
 
@@ -236,8 +236,8 @@ Use `icon-left` or `icon-right` slots to pass icons into a chip. Place the X rem
 
 ```html
 <div>
-  <cdr-chip>Text and icon left <icon-heart-stroke inherit-color size="small" slot="icon-left"/></cdr-chip>
-  <cdr-chip>Text and icon right <icon-check-lg size="small" inherit-color slot="icon-right"/></cdr-chip>
+  <cdr-chip>Text and icon left <template v-slot:icon-left><icon-heart-stroke inherit-color size="small"/></template></cdr-chip>
+  <cdr-chip>Text and icon right <template v-slot:icon-right><icon-check-lg size="small" inherit-color/></template></cdr-chip>
 </div>
 ```
 </cdr-doc-example-code-pair>
@@ -257,18 +257,20 @@ For chips that toggle a single selection on and off, use the click event and d
     @click="toggle"
     :aria-pressed="toggled ? 'true' : 'false'"
   >
-    <icon-heart-stroke
-      slot="icon-left"
-      size="small"
-      inherit-color
-      v-if="!toggled"
-    />
-    <icon-heart-fill
-      slot="icon-left"
-      size="small"
-      inherit-color
-      v-else
-    />
+    <template v-slot:icon-left>
+      <icon-heart-stroke
+        size="small"
+        inherit-color
+        v-if="!toggled"
+      />
+    </template>
+    <template v-slot:icon-left>
+      <icon-heart-fill
+        size="small"
+        inherit-color
+        v-else
+      />
+    </template>
     Toggle
   </cdr-chip>
 </div>
@@ -286,7 +288,7 @@ Filter chips add a visual representation of user selected filters. Filter chips 
 ```html
 <div>
   <cdr-checkbox v-model="filtered" id="filter-checkbox" @change="updateFilter">Add Filter</cdr-checkbox>
-  <cdr-chip v-if="filtered" @click="updateFilter" aria-controls="filter-checkbox" aria-pressed="true"> Remove filter <icon-x-lg size="small" slot="icon-right"/></cdr-chip>
+  <cdr-chip v-if="filtered" @click="updateFilter" aria-controls="filter-checkbox" aria-pressed="true"> Remove filter <template v-slot:icon-right><icon-x-lg size="small" /></template></cdr-chip>
 </div>
 ```
 </cdr-doc-example-code-pair>

--- a/docs/components/form-group/README.md
+++ b/docs/components/form-group/README.md
@@ -145,7 +145,7 @@ Rather than passing a `label` prop, the label element can be customized using th
 
 ```html
 <cdr-form-group>
-  <template slot="label">
+  <template v-slot:label>
     <cdr-text style="font-size: 24px;">Optional Label Slot Override</cdr-text>
   </template>
   <cdr-checkbox

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -413,7 +413,7 @@ Input field designed to accept numerical input. Launches the numerical keyboard 
 
 ## Input with Link Text
 
-Input field with link text on right.
+Input field with link text on right. The link should describe it's relationship to the input field either through it's text content or an aria-label.
 
 
 <cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, CdrLink'})" :codeMaxHeight="false" :model="{defaultModel: ''}">
@@ -434,7 +434,7 @@ Input field with link text on right.
 
 ## Input with Info Action
 
-Input field with icon outside the input field on right.
+Input field with icon wrapped in an actionable element outside the input field on right. The actionable element should have an aria-label that explains it's relationship to the input field and what happens when you click on it.
 
 <cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconInformationFill, CdrLink'})" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
@@ -458,7 +458,7 @@ Input field with icon outside the input field on right.
 
 ## Input with Helper Text
 
-Input field with helper or hint text below the input field. If the input is in an error state, the error messaging slot will override this text. Helper text should be used instead of the HTML `placeholder` attribute to provide additional information or context about the input.
+Input field with helper or hint text below the input field. If the input is in an error state, the error messaging slot will override this text. Helper text should be used instead of the HTML `placeholder` attribute to provide additional information or context about the input.  Helper text is automatically linked to the input field through the `aria-describedby` attribute.
 
 <cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
@@ -478,7 +478,7 @@ Input field with helper or hint text below the input field. If the input is in a
 
 ## Input with Helper Text Above
 
-Input field with helper or hint text rendered above the input field. Helper text should be used instead of the HTML `placeholder` attribute to provide additional information or context about the input.
+Input field with helper or hint text rendered above the input field. Helper text should be used instead of the HTML `placeholder` attribute to provide additional information or context about the input. Helper text is automatically linked to the input field through the `aria-describedby` attribute.
 
 <cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{defaultModel: ''}">
 
@@ -542,7 +542,7 @@ Input field with icon inserted into the input field on right. Icon is decorative
 
 ## Input with Actions
 
-Input field with icon buttons inserted to the right. Up to 2 buttons can be passed into the `post-icon` slot. Each button should have the `cdr-input__button` utility class applied to it.
+Input field with icon buttons inserted to the right. Up to 2 buttons can be passed into the `post-icon` slot. Each button should have the `cdr-input__button` utility class applied to it. Each button should indicate it's function and relationship to the input field through either an `aria-label` or a tooltip.
 
 <cdr-doc-example-code-pair repository-href="/src/components/input" :sandbox-data="Object.assign({}, $page.frontmatter.sandboxData, {components: 'CdrInput, IconCreditCard, IconXLg, CdrTooltip, CdrButton'})" :codeMaxHeight="false"  :model="{defaultModel: ''}">
 
@@ -610,6 +610,8 @@ This component has compliance with WCAG guidelines by:
 - When hiding a label, the `aria-label` attribute is set to the `label` value
 
 The HTML `placeholder` attribute should not be used as it creates an inaccessible experience when the placeholder content disappears as soon as the user begins typing into the input field. Instead the `helper-text` or `info` slots should be used to provide any additional information needed to complete the input.
+
+Any additional actionable elements related to the input field, which may be external to the input component or passed in via the `info`, `info-action`, or `post-icon` slots, should indicate their function and relationship to the input field through their text content, and `aria-label`, or a tooltip.
 
 <hr>
 

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -367,7 +367,7 @@ Error messaging will override helper text rendered in the bottom position.
   :error="modelError"
   @blur="validateInput"
 >
-  <template slot="helper-text">
+  <template v-slot:helper-text>
     Must be 4 or less characters
   </template>
 </cdr-input>
@@ -424,7 +424,7 @@ Input field with link text on right.
   :background="backgroundColor"
   label="Input label"
 >
-  <template slot="info">
+  <template v-slot:info>
     <cdr-link href="#" modifier="standalone">Information link</cdr-link>
   </template>
 </cdr-input>
@@ -444,11 +444,13 @@ Input field with icon outside the input field on right.
   :background="backgroundColor"
   label="Input label"
 >
-  <cdr-link tag="button" slot="info-action">
-    <icon-information-fill
-      inherit-color
-    />
-  </cdr-link>
+  <template v-slot:info-action>
+    <cdr-link tag="button">
+      <icon-information-fill
+        inherit-color
+      />
+    </cdr-link>
+  </template>
 </cdr-input>
 ```
 
@@ -466,7 +468,7 @@ Input field with helper or hint text below the input field. If the input is in a
   :background="backgroundColor"
   label="Input label"
 >
-  <template slot="helper-text-bottom">
+  <template v-slot:helper-text-bottom>
     Helper or additional text
   </template>
 </cdr-input>
@@ -486,7 +488,7 @@ Input field with helper or hint text rendered above the input field. Helper text
   :background="backgroundColor"
   label="Input label"
 >
-  <template slot="helper-text-top">
+  <template v-slot:helper-text-top>
     Helper or additional text
   </template>
 </cdr-input>
@@ -506,11 +508,9 @@ Input field with icon inserted into the input field on left. Icon is decorative 
   :background="backgroundColor"
   label="Input label"
 >
-  <IconLocationPinStroke
-    slot="pre-icon"
-    class="cdr-button__icon"
-    inherit-color
-  />
+  <template v-slot:pre-icon>
+    <icon-location-pin-stroke inherit-color />
+  </template>
 </cdr-input>
 ```
 
@@ -528,10 +528,12 @@ Input field with icon inserted into the input field on right. Icon is decorative
   :background="backgroundColor"
   label="Input label"
 >
-  <IconCreditCard
-    slot="post-icon"
-    inherit-color
-  />
+  <template v-slot:post-icon>
+    <icon-credit-card
+      inherit-color
+      class="cdr-button__icon"
+    />
+  </template>
 </cdr-input>
 ```
 
@@ -552,16 +554,17 @@ Input field with icon buttons inserted to the right. Up to 2 buttons can be pass
     label="Input label"
 
   >
-    <template slot="post-icon">
+    <template v-slot:post-icon>
       <cdr-tooltip class="cdr-input__button" id="input-tooltip">
-        <cdr-button
-          :icon-only="true"
-          slot="trigger"
-        >
-          <icon-x-lg
-            inherit-color
-          />
-        </cdr-button>
+        <template v-slot:trigger>
+          <cdr-button
+            :icon-only="true"
+          >
+            <icon-x-lg
+              inherit-color
+            />
+          </cdr-button>
+        </template>
 
         click me to clear this input!
       </cdr-tooltip>
@@ -583,16 +586,17 @@ Input field with icon buttons inserted to the right. Up to 2 buttons can be pass
 
     size="large"
   >
-    <cdr-button
-      slot="post-icon"
-      :icon-only="true"
-      size="large"
-      class="cdr-input__button"
-    >
-      <icon-credit-card
-        inherit-color
-      />
-    </cdr-button>
+    <template v-slot:post-icon>
+      <cdr-button
+        :icon-only="true"
+        size="large"
+        class="cdr-input__button"
+      >
+        <icon-credit-card
+          inherit-color
+        />
+      </cdr-button>
+    </template>
   </cdr-input>
 </div>
 ```

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -130,7 +130,7 @@
   @closed="opened = false"
   aria-described-by="description"
 >
-  <template slot="title">
+  <template v-slot:title>
     <cdr-text
       tag="h3"
       class="title-header"
@@ -170,7 +170,7 @@ When rendering multiple modals on a single page you can reduce your markup size 
   @closed="opened = false"
   aria-described-by="description"
 >
-  <template slot="title">
+  <template v-slot:title>
     <cdr-text
       tag="h3"
       class="title-header"
@@ -265,7 +265,7 @@ If the `title` slot is left empty, the `label` prop will be rendered as the titl
 When using the `label` slot, add CdrText to use the appropriate header styles.
 
 ```vue{3,4}
-<template slot="title">
+<template v-slot:title>
   <cdr-text
     tag="h1"
     class="custom-text-class"

--- a/docs/components/pagination/README.md
+++ b/docs/components/pagination/README.md
@@ -206,14 +206,30 @@ At the xs breakpoint, pagination adapts to a Select component using the native U
 This component complies with accessibility guidelines by doing the following:
 
 - Wraps the pagination links in a `<nav>` element to let screen readers recognize the pagination controls
-- Sets `aria-label="pagination"` to describe the type of navigation. TODO: forLabel prop if not page navigation!!!
+- Sets `aria-label="pagination"` to describe the type of navigation.
 - Indicates the active page by adding `aria-current="page"` to the link that points to the current page
 
-View the videos at [a11ymattters, Accessible Pagination](http://www.a11ymatters.com/pattern/pagination/) for a demonstration of before and after pagination tests using a screen reader voiceover.
+If you are building an intra-page button based pagination, the `forLabel` property must be used to indicate what content is being paginated. For example,
+
+```
+<div>
+  <div>{{ reviews content }}</div>
+
+  <cdr-pagination
+    link-tag="button"
+    for-label="pagination for reviews"
+
+    :pages="pages"
+    :total-pages="5"
+    v-model="page"
+  />
+</div>
+
+```
 
 <br />
 
-This component has compliance WCAG guidelines by:
+This component has compliance with WCAG guidelines by:
 - [WCAG 2.4.8](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0&showtechniques=248#location): Information about the user's location within a set of Web pages is available
 - [WCAG 3.2.3](https://www.w3.org/TR/UNDERSTANDING-WCAG20/consistent-behavior-consistent-locations.html): Navigation patterns follow a consistent pattern. Only position pagination component at the bottom of the page
 - [WCAG 2.4.3](https://www.w3.org/WAI/WCAG21/quickref/?versions=2.0#qr-navigation-mechanisms-focus-order): Focus state receives focus in an order that preserves meaning

--- a/docs/components/pagination/README.md
+++ b/docs/components/pagination/README.md
@@ -101,21 +101,33 @@
               {
                 "name": "navigate",
                 "arguments": "pageNumber, url, event",
-                "description": "$emit event fired when page changes based on user interaction by clicking a link or selecting an option from the select on mobile."
+                "description": "$emit event fired when page changes based on user interaction by clicking a link or selecting an option from the select on mobile. `event.preventDefault()` can be used to override the default link navigation behavior"
               }
             ],
             "scopedSlots": [
               {
                 "name": "link",
-                "description": "Scoped slot used to override the default page links used. Useful for integrating with client-side routing. See \"Scoped Slots and vue-router\" below for exposed prop API."
+                "description": "Scoped slot used to override the default page links used. Useful for integrating with client-side routing.",
+                "alert": {
+                  "type": "deprecated",
+                  "description": "The link scoped slot has been deprecated, use an event handler on the `navigate` event instead to customize link navigation behavior"
+                },
               },
               {
                 "name": "prevLink",
-                "description": "Scoped slot used to override the default previous page link. Useful for integrating with client-side routing. See \"Scoped Slots and vue-router\" below for exposed prop API."
+                "description": "Scoped slot used to override the default previous page link. Useful for integrating with client-side routing.",
+                "alert": {
+                  "type": "deprecated",
+                  "description": "The prevLink scoped slot has been deprecated, use an event handler on the `navigate` event instead to customize link navigation behavior"
+                },
               },
               {
                 "name": "nextLink",
-                "description": "Scoped slot used to override the default next page link. Useful for integrating with client-side routing. See \"Scoped Slots and vue-router\" below for exposed prop API."
+                "description": "Scoped slot used to override the default next page link. Useful for integrating with client-side routing.",
+                "alert": {
+                  "type": "deprecated",
+                  "description": "The nextLink scoped slot has been deprecated, use an event handler on the `navigate` event instead to customize link navigation behavior"
+                },
               }
             ],
           }
@@ -163,107 +175,24 @@ By default, CdrPagination assumes that you are navigating through pages on a sit
 ```
 </cdr-doc-example-code-pair>
 
-## Link Scoped Slots
+## Overriding Default Navigation
 
-The scoped slots can be used to override the default links rendered in the pagination. Useful for integrating with client-side routing, as a `router-link` can be rendered instead of a plain `a` tag. Pagination exposes 3 link scopedSlots: `link`, `prevLink`, and `nextLink`.
+TODO: vue-router support...customize navigation logic...uhhhh
 
-The 'link' slot scope exposes the following prop object:
-
-```js
-attrs: {
-  class,
-  'aria-label',
-  'aria-current',
-  ref:,
-},
-href,
-page,
-content,
-click,
-```
-
-- `class`: a class to be applied to the link in order to match pagination styling
-- `aria-label`: default aria-label for this link
-- `aria-current`: reflects whether current link is the currently selected page
-- `ref`: vue ref for tracking the element. Required for internal component behavior
-- `href`: href that the link points to by default
-- `page`: the page number that corresponds to this link. NOTE: that you must manually update your v-model attribute to be the value of `page` whenever this link is clicked
-- `content`: the default content for that link
-- `click`: function ran when element is clicked. Required for internal component behavior
-
-The `prevLink` and `nextLink` slot scopes expose the following prop object:
-
-```js
-attrs: {
-  class,
-  'aria-label',
-  ref,
-},
-href,
-page,
-content,
-iconClass,
-iconComponent,
-iconPath,
-click,
-```
-
-- `class`: a class to be applied to the link in order to match pagination styling
-- `aria-label`: default aria-label for this link
-- `ref`: vue ref for tracking the element for internal component behavior
-- `href`: href that the link points to by default
-- `page`: the page number that corresponds to this link. NOTE: that you must manually update your v-model attribute to be the value of `page` whenever this link is clicked
-- `content`: the default content for that link
-- `iconClass`: a class to be applied to the prev/next arrow icon in order to match pagination styling
-- `iconPath`: the path to the icon in the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/) used for this link
-- `iconComponent`: name of the component used for this link
-- `click`: function ran when element is clicked. Required for internal component behavior
-
-<cdr-doc-example-code-pair repository-href="/src/components/accordion" :sandbox-data="$page.frontmatter.sandboxData" :model="{ page: 2, pages: [{page: 1, url: '1'}, {page: 2, url: '2'}, {page: 3, url: '3'}] }">
+<cdr-doc-example-code-pair repository-href="/src/components/accordion" :sandbox-data="$page.frontmatter.sandboxData" :model="{ lastNavigation: '', page: 3, pages: [{page: 1, url: '#'}, {page: 2, url: '#'}, {page: 3, url: '#'}, {page: 4, url: '#'}, {page: 5, url: '#'}] }" :methods="{handleNavigation(num, url, e) {e.preventDefault(); this.lastNavigation = num }}">
 
 ```html
-<cdr-pagination
-  :pages="pages"
-  :total-pages="3"
-  v-model="page"
->
-  <!-- Previous -->
-  <template slot="prevLink" slot-scope="prevLink">
-    <p
-      v-bind="prevLink.attrs"
-      @click="prevLink.click"
-    >
-      <component
-        :is="prevLink.iconComponent"
-        :class="prevLink.iconClass"
-      />
-      {{ prevLink.content }}
-    </p>
-  </template>
-  <!-- Single Page links -->
-  <template slot="link" slot-scope="link">
-    <p
-      v-bind="link.attrs"
-      @click="link.click"
-    >
-      {{ link.page }}
-    </p>
-  </template>
-  <!-- Next -->
-  <template slot="nextLink" slot-scope="nextLink">
-    <p
-      v-bind="nextLink.attrs"
-      @click="nextLink.click"
-    >
-      {{ nextLink.content }}
-      <component
-        :is="nextLink.iconComponent"
-        :class="nextLink.iconClass"
-      />
-    </p>
-  </template>
-</cdr-pagination>
+<div>
+  <cdr-pagination
+    :pages="pages"
+    :total-pages="5"
+    v-model="page"
+    @navigate="handleNavigation"
+  />
+  Last Navigation: {{ lastNavigation }}
+</div>
 ```
+
 </cdr-doc-example-code-pair>
 
 ## Pagination @ xs
@@ -277,7 +206,7 @@ At the xs breakpoint, pagination adapts to a Select component using the native U
 This component complies with accessibility guidelines by doing the following:
 
 - Wraps the pagination links in a `<nav>` element to let screen readers recognize the pagination controls
-- Sets `aria-label="pagination"` to describe the type of navigation
+- Sets `aria-label="pagination"` to describe the type of navigation. TODO: forLabel prop if not page navigation!!!
 - Indicates the active page by adding `aria-current="page"` to the link that points to the current page
 
 View the videos at [a11ymattters, Accessible Pagination](http://www.a11ymatters.com/pattern/pagination/) for a demonstration of before and after pagination tests using a screen reader voiceover.
@@ -359,73 +288,6 @@ Pagination adapts to a Select component with a native UI dropdown menu on XS bre
 The **CdrPagination** component provides a current page number control and renders a list of links. The current page value should be bound using `v-model` in your app.
 
 The **CdrPagination** component does not make data calls, render or track paginated data, or handle routing beyond simple anchor links. However, it does emit events if you need to customize routing or need to add additional application logic.
-
-## Scoped Slots and vue-router
-
-Previous, next, and individual page links can have their template overridden via scoped slots. While this isn't advisable under normal circumstances, it is necessary to make the component work with vue-router. It is similar to the [scoped slot example](#link-scoped-slots) but uses `router-link` with no click event (when paired with a computed prop v-model):
-
-```vue
-<cdr-pagination
-  :pages="pages"
-  :total-pages="20"
-  v-model="page"
->
-  <!-- Previous -->
-  <template v-slot:prevLink="prevLink">
-    <router-link
-      v-bind="prevLink.attrs"
-      :to="{ query: { 'page': prevLink.page } }"
-      replace
-    >
-      <component
-        :is="prevLink.iconComponent"
-        :class="prevLink.iconClass"
-      />
-      {{ prevLink.content }}
-    </router-link>
-  </template>
-  <!-- Single Page links -->
-  <template v-slot:link="link">
-    <router-link
-      v-bind="link.attrs"
-      :to="{ query: { 'page': link.page } }"
-      replace
-    >
-      {{ link.page }}
-    </router-link>
-  </template>
-  <!-- Next -->
-  <template v-slot:nextLink="nextLink">
-    <router-link
-      v-bind="nextLink.attrs"
-      :to="{ query: { 'page': nextLink.page } }"
-      replace
-    >
-      {{ nextLink.content }}
-      <component
-        :is="nextLink.iconComponent"
-        :class="nextLink.iconClass"
-      />
-    </router-link>
-  </template>
-</cdr-pagination>
-
-...
-
-<script>
-...
-computed: {
-  page: {
-    get() {
-      return parseInt(this.$route.query['page'], 10) || 1;
-    },
-    set() {
-      // No need to do anything for the component here
-    },
-  },
-},
-</script>
-```
 
 ### SEO
 

--- a/docs/components/pagination/README.md
+++ b/docs/components/pagination/README.md
@@ -166,8 +166,8 @@ By default, CdrPagination assumes that you are navigating through pages on a sit
 
 ```html
 <cdr-pagination
-  linkTag="button"
-  forLabel="Pagination for user reviews"
+  link-tag="button"
+  for-label="Pagination for user reviews"
   :pages="pages"
   :total-pages="5"
   v-model="page"
@@ -177,7 +177,7 @@ By default, CdrPagination assumes that you are navigating through pages on a sit
 
 ## Overriding Default Navigation
 
-TODO: vue-router support...customize navigation logic...uhhhh
+By default pagination uses anchor elements which navigate the users web browser when clicked. This behavior can be overriden by adding a handler to the `navigate` event which emits `(currentPage, currentUrl, event)` and calling `event.preventDefault()` in the handler function. The `currentPage` and `currentUrl` can then be used to implement router based navigation or programmatically navigate the page. This can also be used in conjunction with the `link-tag` property to render a button based pagination.
 
 <cdr-doc-example-code-pair repository-href="/src/components/accordion" :sandbox-data="$page.frontmatter.sandboxData" :model="{ lastNavigation: '', page: 3, pages: [{page: 1, url: '#'}, {page: 2, url: '#'}, {page: 3, url: '#'}, {page: 4, url: '#'}, {page: 5, url: '#'}] }" :methods="{handleNavigation(num, url, e) {e.preventDefault(); this.lastNavigation = num }}">
 

--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -124,9 +124,11 @@ CdrPopover is a wrapper component that accepts a trigger element and popover con
 
 ```html
 <cdr-popover id="popover-example" position="top">
-  <cdr-button slot="trigger">
-    Click me
-  </cdr-button>
+  <template v-slot:trigger>
+    <cdr-button>
+      Click me
+    </cdr-button>
+  </template>
   <div>
     I provide additional information to the user
   </div>

--- a/docs/components/radio/README.md
+++ b/docs/components/radio/README.md
@@ -157,7 +157,7 @@ Default and standard spacing for radio buttons.
 <div>
   <cdr-form-group>
 
-    <template slot="label">
+    <template v-slot:label>
       <span id="legend-1">Default Radio Example</span>
     </template>
     <cdr-radio
@@ -202,7 +202,7 @@ Different sizing for radio buttons.
 <div>
   <cdr-form-group>
 
-    <template slot="label">
+    <template v-slot:label>
       <span id="legend-2">Radio Size Example</span>
     </template>
 
@@ -250,7 +250,7 @@ Custom styles for radio buttons.
 <div>
   <cdr-form-group>
 
-    <template slot="label">
+    <template v-slot:label>
       <span id="legend-3">Custom Radio Example</span>
     </template>
     <cdr-radio

--- a/docs/components/selects/README.md
+++ b/docs/components/selects/README.md
@@ -263,7 +263,7 @@ Select control with link text on right.
   prompt="Prompt text"
   :options="defaultOptions"
 >
-  <template slot="info">
+  <template v-slot:info>
     <cdr-link
       href="#/"
       modifier="standalone"
@@ -281,7 +281,7 @@ Select control with link text on right.
   :options="defaultOptions"
   disabled
 >
-  <template slot="info">
+  <template v-slot:info>
     <cdr-link
       href="#/"
       modifier="standalone"
@@ -309,7 +309,7 @@ Select control with icon outside select field on right.
   prompt="Prompt text"
   :options="defaultOptions"
 >
-  <template slot="info-action">
+  <template v-slot:info-action>
     <cdr-link tag="button">
       <icon-information-fill/>
     </cdr-link>
@@ -334,7 +334,7 @@ Input field with helper or hint text below the input field.
   prompt="Prompt text"
   :options="defaultOptions"
 >
-  <template slot="helper-text">
+  <template v-slot:helper-text>
     This is helper text.
   </template>
 </cdr-select>
@@ -347,7 +347,7 @@ Input field with helper or hint text below the input field.
   :options="defaultOptions"
   disabled
 >
-  <template slot="helper-text">
+  <template v-slot:helper-text>
     This is helper text.
   </template>
 </cdr-select>

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -123,9 +123,13 @@ CdrTooltip is a wrapper component that accepts a trigger element and tooltip con
 
 ```html
 <cdr-tooltip id="tooltip-example" position="top">
-  <cdr-button slot="trigger" :icon-only="true" :with-background="true">
-    <icon-information-stroke slot="icon"/>
-  </cdr-button>
+  <template v-slot:trigger>
+    <cdr-button :icon-only="true" :with-background="true">
+      <template v-slot:icon>
+        <icon-information-stroke/>
+      </template>
+    </cdr-button>
+  </template>
   <div>
     On hover or focus, I provide more information about what this button does
   </div>
@@ -155,7 +159,9 @@ CdrTooltip can also be controlled programmatically using the `open` prop. Howeve
     :with-background="true"
     aria-describedby="tooltip-custom-example"
   >
-    <icon-information-stroke slot="icon"/>
+    <template v-slot:icon>
+      <icon-information-stroke/>
+    </template>
   </cdr-button>
   <cdr-tooltip id="tooltip-custom-example" position="top" :open="open">
     <div>

--- a/docs/getting-started/as-a-developer/README.md
+++ b/docs/getting-started/as-a-developer/README.md
@@ -219,19 +219,19 @@ In this example, the `size` prop accepts a string denoting size at different bre
 
 Some components use slots for content distribution. Most components will have a single default slot; others will have named slots or scoped slots. Slots are listed as part of the API for all components. For more information about slots, read [Vue's Slots documentation](https://vuejs.org/v2/guide/components-slots.html).
 
-Adding content to a default slot
+Adding content to a component that has a default slot
 
 ```html
 <cdr-button>I'm content in the default slot</cdr-button>
 ```
 
-Adding content to a named slot
+Adding content to a component that has named slots
 
 ```html
 <my-component>
-  <slot name="header">I'm content in the header slot</slot>
+  <template v-slot:header>I'm content in the header slot</template>
 
-  <slot name="footer">I'm content in the footer slot</slot>
+  <template v-slot:footer>I'm content in the footer slot</template>
 </my-component>
 ```
 

--- a/docs/getting-started/as-a-developer/README.md
+++ b/docs/getting-started/as-a-developer/README.md
@@ -239,10 +239,7 @@ Adding content to a scoped slot
 
 ```html
 <my-component>
-  <template
-    slot="name-of-the-slot"
-    slot-scope="scopeObject"
-  >
+  <template v-slot:name-of-the-slot="scopeObject">
     {{scopeObject.content}} {{scopeObject.someAttribute}}
   </template>
 </my-component>

--- a/docs/patterns/alerts/README.md
+++ b/docs/patterns/alerts/README.md
@@ -96,7 +96,7 @@ They arehey appear over the interface and block further interactions until an ac
   aria-described-by="description"
   role="alertdialog"
 >
-  <template slot="title">
+  <template v-slot:title>
     <cdr-text
       tag="h3"
       class="title-header"

--- a/docs/patterns/forms/README.md
+++ b/docs/patterns/forms/README.md
@@ -87,7 +87,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   :error="errorMessage"
   @blur="validate"
 >
-  <template slot="helper-text-top">
+  <template v-slot:helper-text-top>
     To call if there's an issue with your order.
   </template>
 </cdr-input>
@@ -127,7 +127,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
     :optional="true"
     class="form-space"
   >
-    <template slot="helper-text-top">
+    <template v-slot:helper-text-top>
       Is there another name you prefer to go by?
     </template>
   </cdr-input>
@@ -256,7 +256,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   style="width: 160px;"
   @input="restrictInput"
 >
-  <template slot="helper-text-top">
+  <template v-slot:helper-text-top>
     Three digit number on the back.
   </template>
 </cdr-input>
@@ -285,7 +285,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   style="width: 160px;"
   :numeric="true"
 >
-  <template slot="helper-text-top">
+  <template v-slot:helper-text-top>
     Use MM/YY format.
   </template>
 </cdr-input>
@@ -339,14 +339,18 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   <option value="male">Female</option>
   <option value="female">Male</option>
   <option value="describe">Prefer to describe</option>
-  <cdr-popover id="popover-example" position="top" slot="info">
-    <cdr-link slot="trigger" tag="button">
-      <icon-information-stroke inherit-color/>
-    </cdr-link>
-    <div>
-      Why do we ask for gender? This popover explains what this information is used for.
-    </div>
-  </cdr-popover>
+  <template v-slot:info>
+    <cdr-popover id="popover-example" position="top">
+      <template v-slot:trigger>
+        <cdr-link tag="button">
+          <icon-information-stroke inherit-color/>
+        </cdr-link>
+      </template>
+      <div>
+        Why do we ask for gender? This popover explains what this information is used for.
+      </div>
+    </cdr-popover>
+  </template>
 </cdr-select>
 
 <cdr-input

--- a/docs/release-notes/fall-2019/README.md
+++ b/docs/release-notes/fall-2019/README.md
@@ -151,7 +151,7 @@ After:
   :opened="opened"
   @accordion-toggle="opened = !opened"
 >
-  <template slot="label">
+  <template v-slot:label>
     How do I find my member number?
   </template>
   <cdr-text>

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -55,7 +55,27 @@ We have created a new `cdr-color-background-brand-spruce` color token (TODO: inf
 
 ## Deprecations
 
-### TODO: ????
+### Vue 3: Update Slot Syntax
+
+Vue 2.6 introduced a new syntax for passing slot content into components. The old syntax is removed from Vue 3 and we recommend updating your codebase to make use of the new slot syntax to simplify the upgrade process in the future.
+
+```
+<!-- Named slots -->
+<template slot="label">old named slot syntax</template>
+<template v-slot:label>new named slot syntax</slot>
+
+<!-- Scoped slots -->
+<template slot="link" slot-scope="link">old scoped slot syntax {{ link.name }}</template>
+<template v-slot:link="link">new scoped slot syntax {{ link.name }}</template>
+```
+
+The examples on this doc site have been updated to make use of the new syntax, see the [Vue documentation](https://vuejs.org/v2/guide/components-slots.html#Named-Slots) for more information.
+
+### CdrBreadcrumb and CdrPagination Scoped Slots
+
+CdrBreadcrumb and CdrPagination both allow for passing in a scoped slot for rendering their link elements which was intended to support things like vue-router which must override the default link navigation behavior. This feature increased the complexity of both components, making it difficult to maintain and improve the components over time. It requires that consumers bind multiple attributes to the slot element to ensure a consistent UI. Most importantly, this functionality is better served through an event handler which would allow the Cedar components to remain simple and consistent but give consumers the flexibility to customize their behavior.
+
+ We are planning to remove support for scoped slots in both components as part of our future Vue 3 updates. See the [CdrBreadcrumb](TODO ADD EXAMPLE) or [CdrPagination](TODO ADD EXAMPLE) pages for examples of how to override their default navigation behavior. Please reach out to the Cedar team if you have any questions or concerns about this change.
 
 ## Breaking Changes
 

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -59,7 +59,7 @@ We have created a new `cdr-color-background-brand-spruce` color token (TODO: inf
 
 CdrBreadcrumb and CdrPagination both allow for passing in a scoped slot for rendering their link elements which was intended to support things like vue-router which must override the default link navigation behavior. This feature increased the complexity of both components, making it difficult to maintain and improve the components over time. It requires that consumers bind multiple attributes to the slot element to ensure a consistent UI. Most importantly, this functionality is better served through an event handler which would allow the Cedar components to remain simple and consistent but give consumers the flexibility to customize their behavior.
 
- We are planning to remove support for scoped slots in both components as part of our future Vue 3 updates. See the [CdrBreadcrumb](TODO ADD EXAMPLE) or [CdrPagination](TODO ADD EXAMPLE) pages for examples of how to override their default navigation behavior. Please reach out to the Cedar team if you have any questions or concerns about this change.
+ We are planning to remove support for scoped slots in both components as part of our future Vue 3 updates. See the [CdrBreadcrumb](../../components/breadcrumb/#custom-navigation) or [CdrPagination](../../components/pagination/#overriding-default-navigation) pages for examples of how to override their default navigation behavior. Please reach out to the Cedar team if you have any questions or concerns about this change.
 
 ### Vue 3: Update Slot Syntax
 

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -55,18 +55,26 @@ We have created a new `cdr-color-background-brand-spruce` color token (TODO: inf
 
 ## Deprecations
 
+### CdrBreadcrumb and CdrPagination Scoped Slots
+
+CdrBreadcrumb and CdrPagination both allow for passing in a scoped slot for rendering their link elements which was intended to support things like vue-router which must override the default link navigation behavior. This feature increased the complexity of both components, making it difficult to maintain and improve the components over time. It requires that consumers bind multiple attributes to the slot element to ensure a consistent UI. Most importantly, this functionality is better served through an event handler which would allow the Cedar components to remain simple and consistent but give consumers the flexibility to customize their behavior.
+
+ We are planning to remove support for scoped slots in both components as part of our future Vue 3 updates. See the [CdrBreadcrumb](TODO ADD EXAMPLE) or [CdrPagination](TODO ADD EXAMPLE) pages for examples of how to override their default navigation behavior. Please reach out to the Cedar team if you have any questions or concerns about this change.
+
 ### Vue 3: Update Slot Syntax
 
-Vue 2.6 introduced a new syntax for passing slot content into components. The old syntax is removed from Vue 3 and we recommend updating your codebase to make use of the new slot syntax to simplify the upgrade process in the future.
+Vue 2.6 introduced a new syntax for passing slot content into components. The old syntax is removed from Vue 3 and we recommend updating your codebase to make use of the new slot syntax to simplify the upgrade process in the future. Note that the new `v-slot` syntax can only be used on a `template` tag, however those additional `template` tags will not be included in the rendered HTML.
 
 ```
 <!-- Named slots -->
-<template slot="label">old named slot syntax</template>
-<template v-slot:label>new named slot syntax</slot>
+<span slot="slotname">old named slot syntax</span>
+<template v-slot:slotname>
+  <span>new named slot syntax<span>
+</template>
 
 <!-- Scoped slots -->
-<template slot="link" slot-scope="link">old scoped slot syntax {{ link.name }}</template>
-<template v-slot:link="link">new scoped slot syntax {{ link.name }}</template>
+<template slot="slotname" slot-scope="scopeObject">old scoped slot syntax {{ scopeObject.name }}</template>
+<template v-slot:slotname="scopeObject">new scoped slot syntax {{ scopeObject.name }}</template>
 ```
 
 The examples on this doc site have been updated to make use of the new syntax, see the [Vue documentation](https://vuejs.org/v2/guide/components-slots.html#Named-Slots) for more information.
@@ -75,7 +83,7 @@ The examples on this doc site have been updated to make use of the new syntax, s
 
 CdrBreadcrumb and CdrPagination both allow for passing in a scoped slot for rendering their link elements which was intended to support things like vue-router which must override the default link navigation behavior. This feature increased the complexity of both components, making it difficult to maintain and improve the components over time. It requires that consumers bind multiple attributes to the slot element to ensure a consistent UI. Most importantly, this functionality is better served through an event handler which would allow the Cedar components to remain simple and consistent but give consumers the flexibility to customize their behavior.
 
- We are planning to remove support for scoped slots in both components as part of our future Vue 3 updates. See the [CdrBreadcrumb](TODO ADD EXAMPLE) or [CdrPagination](TODO ADD EXAMPLE) pages for examples of how to override their default navigation behavior. Please reach out to the Cedar team if you have any questions or concerns about this change.
+We are planning to remove support for scoped slots in both components as part of our future Vue 3 updates. See the [CdrBreadcrumb](../../components/breadcrumb/#custom-navigation) or [CdrPagination](../../components/pagination/#overriding-default-navigation) pages for examples of how to override their default navigation behavior. Please reach out to the Cedar team if you have any questions or concerns about this change.
 
 ## Breaking Changes
 


### PR DESCRIPTION
- marks breadcrumb/pagination scoped slots as deprecated
- documents alternatives to override breadcrumb/pagination navigation
- migrate slot examples to new vue2.6/3 v-slot syntax, add release note warning consumers about the change in vue 3 so they can migrate early

Breadcrumb navigation override example depends on this PR to work: https://github.com/rei/rei-cedar/pull/1038