### PR TITLE
Document utility deprecation

### DIFF
--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -14,6 +14,10 @@ body {
   padding: 0;
 }
 
+h1, h2, h3, h4, h5 {
+  @include cdr-text-heading-serif-strong-600;
+}
+
 .cdr-doc-page-shell {
   display: flex;
 }

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -132,8 +132,217 @@ The Cedar CSS utility classes and CdrText modifier property were intended to all
 
 We have been warning that these files will be deprecated for our past several releases, yet we continue to see new instances of them appear in REI codebases, so we have made the decision to delete them entirely in order to mitigate these ongoing issues with performance and code maintainability.
 
-For teams that need to update to the latest version of Cedar but which use the utility classes or CdrText modifier property too extensively to migrate all at once, we have created a copy of these utility classes in FEDPACK to allow you to incrementally migrate towards @rei/cdr-tokens.
+For teams that need to update to the latest version of Cedar but which use the utility classes or CdrText modifier property too extensively to migrate all at once, we have created a [bitbucket project](https://git.rei.com/users/cowills/repos/cedar-deprecated-utilities/browse) containing those utility class definitions to allow you to incrementally migrate towards @rei/cdr-tokens.
 
-TODO: link to cdr-legacy-utilities fed package, show how to convert to tokens
+#### Example migrations
+
+##### Align Utils
+
+Alignment utilities can be replaced with the equivalent plain CSS
+```html
+<div class="cdr-align-text-center">
+  Deprecated utility
+</div>
+```
+```html
+<template>
+  <div class="your-custom-alignment-class">
+    Using plain CSS
+  </div>
+</template>
+<style lang="scss">
+  .your-custom-alignment-class {
+    text-align: center;
+  }
+</style>
+
+```
+
+##### Color Utils
+
+Color utilities can be replaced with the equivalent value from @rei/cdr-tokens targeting either `background-color`, `color`, or `fill` as appropriate.
+
+```html
+<div class="cdr-color-background-primary">
+  Deprecated background color utility
+</div>
+
+<div class="cdr-color-text-primary">
+  Deprecated text color utility
+</div>
+```
+
+```html
+<template>
+  <div class="your-custom-background-color-class">
+    Using plain CSS/tokens for background color
+  </div>
+
+  <div class="your-custom-text-color-class">
+    Using plain CSS/tokens for text color
+  </div>
+</template>
+<style lang="scss">
+  @import '~@rei/cdr-tokens/dist/scss/cdr-tokens';
+
+  .your-custom-background-color-class {
+    background-color: $cdr-color-background-primary;
+  }
+
+  .your-custom-text-color-class {
+    color: $cdr-color-text-primary;
+  }
+</style>
+```
+
+##### Container Utils
+
+The `cdr-container` and `cdr-container-fluid` utility classes should be replaced with the equivalent mixin from @rei/cdr-tokens. See the [Cedar Responsive article](https://rei.github.io/rei-cedar-docs/foundation/responsive/) for more information on container usage.
+
+```html
+<div class="cdr-container">
+  Deprecated utility
+</div>
+```
+
+```html
+<template>
+  <div class="your-custom-container-class">
+    Using plain CSS/tokens
+  </div>
+</template>
+<style lang="scss">
+  @import '~@rei/cdr-tokens/dist/scss/cdr-tokens';
+
+  .your-custom-container-class {
+    @include cdr-container;
+  }
+</style>
+```
+
+
+##### Display Utils
+
+Display utilities can be replaced with the equivalent plain CSS
+
+```html
+<div class="cdr-display-none">
+  Deprecated utility
+</div>
+```
+```html
+<template>
+  <div class="your-custom-display-class">
+    Using plain CSS
+  </div>
+</template>
+<style lang="scss">
+  .your-custom-display-class {
+    display: none;
+  }
+</style>
+```
+
+##### Space Utils
+
+Space utility classes were a combination of the targeted property and a Cedar spacing token.
+
+| prefix | property |
+|--|--|
+| inset | padding |
+| pl | padding-left |
+| pt | padding-top |
+| pr | padding-right |
+| pb | padding-bottom |
+| px | padding-left and padding-right |
+| py | padding-top and padding-bottom |
+| ml | margin-left |
+| mt | margin-top |
+| mr | margin-right |
+| mb | margin-bottom |
+| mx | margin-left and margin-right |
+| my | margin-top and margin-bottom |
+
+
+```html
+<div class="cdr-space-inset-half-x">
+  Deprecated utility
+</div>
+```
+
+```html
+<template>
+  <div class="your-custom-space-class">
+    Using plain CSS/tokens
+  </div>
+</template>
+<style lang="scss">
+  @import '~@rei/cdr-tokens/dist/scss/cdr-tokens';
+
+  .your-custom-space-class {
+    padding: $cdr-space-half-x;
+  }
+</style>
+```
+
+
+##### Text Utils
+
+Note that the text utility classes were available both as CSS utility classes and via the cdr-text modifier prop. The migration path is the same for both patterns.
+
+```html
+<p class="cdr-text--utility-sans-strong-300">
+  Deprecated utility
+</p>
+
+<cdr-text modifier="utility-sans-strong-300" tag="p">
+  Deprecated modifier
+</cdr-text>
+```
+
+```html
+<template>
+  <p class="your-custom-type-class">
+    Using plain CSS/tokens
+  </p>
+</template>
+<style lang="scss">
+  @import '~@rei/cdr-tokens/dist/scss/cdr-tokens';
+
+  .your-custom-type-class {
+    @include cdr-text-utility-sans-strong-300;
+  }
+</style>
+```
+
+##### Responsive Utilities
+
+The align, display, space, and text utility classes supported breakpoint modifiers as a suffix which would only activate the utility class at the given breakpoint. Those instances should be migrated as described above but additionally use a [breakpoint mixin from @rei/cdr-tokens](https://rei.github.io/rei-cedar-docs/foundation/responsive/#scss-less-utilities).
+
+```html
+<div class="cdr-mb-space-quarter-x\@md">
+  Deprecated responsive utility
+</div>
+```
+
+```html
+<template>
+  <div class="your-custom-responsive-space-class">
+    Using plain CSS/tokens
+  </div>
+</template>
+<style lang="scss">
+  @import '~@rei/cdr-tokens/dist/scss/cdr-tokens';
+
+  @include cdr-md-mq-only {
+    .your-custom-responsive-space-class {
+      margin-bottom: $cdr-space-quarter-x;
+    }
+  }
+
+</style>
+```
+
+
 
 </cdr-doc-table-of-contents-shell>


### PR DESCRIPTION
Rather than create a fedpack NPM package containing the deprecated utility classes, I decided to just stash them in a bitbucket project so that teams using them will be forced to manually copy paste these files into their project: https://git.rei.com/users/cowills/repos/cedar-deprecated-utilities/browse

- An NPM package has an aura of legitimacy to it, 
- an NPM package could theoretically be updated and we want to emphasize that these classes are not maintained or supported whatsoever, 
- i think an NPM dependency with a simple import statement somewhere in the CSS would make it more likely that someone might copy paste that code out of an old project into a new one without even being aware that the classes are long since deprecated (whereas if someone copy pastes these util files from one project to another then...well we cant do much to fix that kind of behavior 😆), 
- and I think forcing teams to copy paste a file with a big WARNING at the top helps emphasize that this is wild west territory.

----------

- Links off to bitbucket project containing deprecated CSS utility classes
- Includes detailed migration steps for each type of utility
- ⚠️  Overrides the default heading tag styling on the doc site to use cdr-text-heading-serif-strong-600 everywhere. Not sure how we had gone so long using the browser defaults without applying a proper heading style there. The h5's on the spring release notes were getting ridiculously tiny 😆 