### PR TITLE
update aria-describedby notes, fix homepage, eradicate utility classes

### DIFF
--- a/docs/.vuepress/components/TextDocOverview.vue
+++ b/docs/.vuepress/components/TextDocOverview.vue
@@ -3,8 +3,7 @@
     <div v-for="modifier in Object.keys(text)" class="stack-1">
       <cdr-text
         tag="h3"
-        modifier="heading-500"
-        class="stack-1"
+        class="cdr-text--heading-500 stack-1"
       >
           {{ formatTitle(modifier) }}
       </cdr-text>
@@ -18,7 +17,7 @@
         <tbody>
           <tr v-for="level in text[modifier]" :key="`${modifier}-${level}`">
             <td>
-              <cdr-text :modifier="`${modifier}-${level}`">{{ modifier }}-{{ level }}</cdr-text>
+              <cdr-text :class="`cdr-text--${modifier}-${level}`">{{ modifier }}-{{ level }}</cdr-text>
             </td>
             <td>
               <cdr-text>cdr-text-{{ modifier }}-{{ level }}</cdr-text>
@@ -28,7 +27,7 @@
       </cdr-table>
     </div>
 
-    <cdr-text tag="h3" modifier="heading-500" class="stack-1">
+    <cdr-text tag="h3" class="cdr-text--heading-500 stack-1">
       Helpers
     </cdr-text>
 
@@ -42,7 +41,7 @@
       <tbody>
         <tr>
           <td>
-            <cdr-text modifier="italic">italic</cdr-text>
+            <cdr-text class="cdr-text--italic">italic</cdr-text>
           </td>
           <td>
             <cdr-text> cdr-text-italic </cdr-text>
@@ -50,7 +49,7 @@
         </tr>
         <tr>
           <td>
-            <cdr-text modifier="strong">strong</cdr-text>
+            <cdr-text class="cdr-text--strong">strong</cdr-text>
           </td>
           <td>
             <cdr-text> cdr-text-strong </cdr-text>
@@ -59,13 +58,13 @@
       </tbody>
     </cdr-table>
 
-    <cdr-text tag="h3" modifier="heading-500" class="stack-1">
+    <cdr-text tag="h3" class="cdr-text--heading-500 stack-1">
       Native Mobile App Tokens
     </cdr-text>
 
     <tokens-typography platform="native" type="header">
 
-    <cdr-text tag="h4" modifier="heading-400" class="stack-1">
+    <cdr-text tag="h4" class="cdr-text--heading-400 stack-1">
       Headings
     </cdr-text>
 
@@ -73,7 +72,7 @@
 
     <tokens-typography platform="native" type="body">
 
-    <cdr-text tag="h4" modifier="heading-400" class="stack-1">
+    <cdr-text tag="h4" class="cdr-text--heading-400 stack-1">
       Body
     </cdr-text>
 
@@ -81,7 +80,7 @@
 
     <tokens-typography platform="native" type="button">
 
-    <cdr-text tag="h4" modifier="heading-400" class="stack-1">
+    <cdr-text tag="h4" class="cdr-text--heading-400 stack-1">
       Buttons
     </cdr-text>
 

--- a/docs/.vuepress/components/TokensCategory.vue
+++ b/docs/.vuepress/components/TokensCategory.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="cdr-container ">
+  <div class="container ">
     <h3 class="category-title">{{ categoryTitle }}</h3>
 
     <div

--- a/docs/.vuepress/theme/Home.vue
+++ b/docs/.vuepress/theme/Home.vue
@@ -18,7 +18,7 @@
     </div>
 
 
-    <div class="cdr-container">
+    <div class="container">
       <cdr-row cols="1 2@md" align="middle" class="stack-4">
         <cdr-col>
           <cdr-img
@@ -102,14 +102,13 @@
 
       <cdr-row cols="1 2@md" class="stack-4">
         <cdr-col>
-          <div class="home-card cdr-space-inset-one-x">
+          <div class="home-card">
             <cdr-row align="middle">
               <cdr-col span="9">
                 <div>
                   <cdr-text
                     tag="h3"
-                    modifier="heading-sans-400"
-                    class="stack-1"
+                    class="home-card-heading stack-1"
                   >Cedar Design Libraries</cdr-text>
                   <cdr-link :href="$withBase('/getting-started/as-a-designer/#design-toolkits')" modifier="standalone">Learn more about the toolkit</cdr-link>
                 </div>
@@ -123,14 +122,13 @@
           </div>
         </cdr-col>
         <cdr-col>
-          <div class="home-card cdr-space-inset-one-x">
+          <div class="home-card">
             <cdr-row align="middle">
               <cdr-col span="9">
                 <div>
                   <cdr-text
                     tag="h3"
-                    modifier="heading-sans-400"
-                    class="stack-1"
+                    class="home-card-heading stack-1"
                   >Vue.js components</cdr-text>
                   <cdr-link href="https://www.npmjs.com/package/@rei/cedar" target="_blank" modifier="standalone">View the NPM repository</cdr-link>
                 </div>
@@ -144,22 +142,20 @@
           </div>
         </cdr-col>
         <cdr-col>
-          <div class="home-card cdr-space-inset-one-x">
+          <div class="home-card">
             <cdr-text
               tag="h3"
-              modifier="heading-sans-400"
-              class="stack-1"
+              class="home-card-heading stack-1"
             >Contribute to Cedar</cdr-text>
             <cdr-text class="stack-1">The Cedar team welcomes contributions from the community. Learn how to become a pilot contributor.  </cdr-text>
             <cdr-link :href="$withBase('/about/contributing-to-cedar/')" modifier="standalone">Help build Cedar</cdr-link>
           </div>
         </cdr-col>
         <cdr-col>
-          <div class="home-card cdr-space-inset-one-x">
+          <div class="home-card">
             <cdr-text
               tag="h3"
-              modifier="heading-sans-400"
-              class="stack-1"
+              class="home-card-heading stack-1"
             >Feedback & support</cdr-text>
             <cdr-text class="stack-1">Questions, ideas, or comments? Your feedback can help improve Cedar. </cdr-text>
             <cdr-link href="mailto:cedar@rei.com" modifier="standalone">Get in touch</cdr-link>
@@ -194,6 +190,10 @@ export default {
 
 <style lang="scss">
 @import "styles/cdr-tokens.scss";
+
+.container {
+  @include cdr-container;
+}
 
 .hero {
   position: relative;
@@ -310,6 +310,11 @@ export default {
   border: 1px solid $cdr-color-border-primary;
   border-radius: $cdr-radius-softer;
   display: block;
+  padding: $cdr-space-one-x;
+}
+
+.home-card-heading {
+  @include cdr-text-heading-sans-400;
 }
 
 .home-resource-icon {

--- a/docs/.vuepress/theme/styles/deprecated-text.css
+++ b/docs/.vuepress/theme/styles/deprecated-text.css
@@ -1,0 +1,551 @@
+
+.cdr-text--italic {
+    font-variation-settings: "ital" 1;
+    font-style: italic;
+    font-style: italic;
+    font-weight: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    font-family: inherit;
+}
+.cdr-text--strong {
+    font-weight: 700;
+    font-size: inherit;
+    line-height: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    font-family: inherit;
+}
+.cdr-text--body-300 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: 0.008rem;
+    font-size: 1.6rem;
+    line-height: 2.6rem;
+}
+.cdr-text--body-400 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: 0;
+    font-size: 1.8rem;
+    line-height: 3rem;
+}
+.cdr-text--body-500 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.016rem;
+    font-size: 2rem;
+    line-height: 3.6rem;
+}
+.cdr-text--body-strong-300 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: 0.008rem;
+    font-size: 1.6rem;
+    line-height: 2.6rem;
+}
+.cdr-text--body-strong-400 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: 0;
+    font-size: 1.8rem;
+    line-height: 3rem;
+}
+.cdr-text--body-strong-500 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 2rem;
+    line-height: 3.6rem;
+}
+.cdr-text--utility-sans-100 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.008rem;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+}
+.cdr-text--utility-sans-200 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.016rem;
+    font-size: 1.4rem;
+    line-height: 1.8rem;
+}
+.cdr-text--utility-sans-300 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.016rem;
+    font-size: 1.6rem;
+    line-height: 2.2rem;
+}
+.cdr-text--utility-sans-400 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.016rem;
+    font-size: 1.8rem;
+    line-height: 2.4rem;
+}
+.cdr-text--utility-sans-500 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.032rem;
+    font-size: 2rem;
+    line-height: 2.6rem;
+}
+.cdr-text--utility-sans-600 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.032rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+.cdr-text--utility-sans-700 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.032rem;
+    font-size: 2.8rem;
+    line-height: 3.6rem;
+}
+.cdr-text--utility-sans-800 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.064rem;
+    font-size: 3.2rem;
+    line-height: 4rem;
+}
+.cdr-text--utility-sans-strong-100 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+}
+.cdr-text--utility-sans-strong-200 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.4rem;
+    line-height: 1.8rem;
+}
+.cdr-text--utility-sans-strong-300 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.6rem;
+    line-height: 2.2rem;
+}
+.cdr-text--utility-sans-strong-400 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.8rem;
+    line-height: 2.4rem;
+}
+.cdr-text--utility-sans-strong-500 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 2rem;
+    line-height: 2.6rem;
+}
+.cdr-text--utility-sans-strong-600 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+.cdr-text--utility-sans-strong-700 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 2.8rem;
+    line-height: 3.6rem;
+}
+.cdr-text--utility-sans-strong-800 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.032rem;
+    font-size: 3.2rem;
+    line-height: 4rem;
+}
+.cdr-text--utility-serif-200 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.008rem;
+    font-size: 1.4rem;
+    line-height: 1.8rem;
+}
+.cdr-text--utility-serif-300 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.008rem;
+    font-size: 1.6rem;
+    line-height: 2.2rem;
+}
+.cdr-text--utility-serif-400 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.016rem;
+    font-size: 1.8rem;
+    line-height: 2.4rem;
+}
+.cdr-text--utility-serif-500 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.032rem;
+    font-size: 2rem;
+    line-height: 2.6rem;
+}
+.cdr-text--utility-serif-600 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.032rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+.cdr-text--utility-serif-700 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.032rem;
+    font-size: 2.8rem;
+    line-height: 3.6rem;
+}
+.cdr-text--utility-serif-800 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 400;
+    letter-spacing: -0.032rem;
+    font-size: 3.2rem;
+    line-height: 4rem;
+}
+.cdr-text--utility-serif-strong-200 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.4rem;
+    line-height: 1.8rem;
+}
+.cdr-text--utility-serif-strong-300 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.6rem;
+    line-height: 2.2rem;
+}
+.cdr-text--utility-serif-strong-400 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.8rem;
+    line-height: 2.4rem;
+}
+.cdr-text--utility-serif-strong-500 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 2rem;
+    line-height: 2.6rem;
+}
+.cdr-text--utility-serif-strong-600 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+.cdr-text--utility-serif-strong-700 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 2.8rem;
+    line-height: 3.6rem;
+}
+.cdr-text--utility-serif-strong-800 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 3.2rem;
+    line-height: 4rem;
+}
+.cdr-text--citation {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.008rem;
+    font-size: 1.2rem;
+    line-height: 1.6rem;
+}
+.cdr-text--eyebrow-100 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0.032rem;
+    font-size: 1.2rem;
+    line-height: 1.8rem;
+    text-transform: uppercase;
+}
+.cdr-text--heading-sans-200 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.4rem;
+    line-height: 1.8rem;
+}
+.cdr-text--heading-sans-300 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.6rem;
+    line-height: 2rem;
+}
+.cdr-text--heading-sans-400 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.8rem;
+    line-height: 2.4rem;
+}
+.cdr-text--heading-sans-500 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 2rem;
+    line-height: 2.6rem;
+}
+.cdr-text--heading-sans-600 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+.cdr-text--heading-serif-200 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.4rem;
+    line-height: 1.8rem;
+}
+.cdr-text--heading-serif-300 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.6rem;
+    line-height: 2rem;
+}
+.cdr-text--heading-serif-400 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.8rem;
+    line-height: 2.4rem;
+}
+.cdr-text--heading-serif-500 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 2rem;
+    line-height: 2.6rem;
+}
+.cdr-text--heading-serif-600 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+.cdr-text--heading-serif-700 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 2.8rem;
+    line-height: 3.2rem;
+}
+.cdr-text--heading-serif-800 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 3.2rem;
+    line-height: 3.6rem;
+}
+.cdr-text--heading-serif-900 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.032rem;
+    font-size: 3.6rem;
+    line-height: 4.4rem;
+}
+.cdr-text--heading-serif-1000 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.032rem;
+    font-size: 4.2rem;
+    line-height: 5rem;
+}
+.cdr-text--heading-serif-1100 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.032rem;
+    font-size: 4.8rem;
+    line-height: 5.6rem;
+}
+.cdr-text--heading-serif-1200 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.032rem;
+    font-size: 5.4rem;
+    line-height: 6.4rem;
+}
+.cdr-text--heading-serif-strong-600 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+.cdr-text--heading-serif-strong-700 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 2.8rem;
+    line-height: 3.2rem;
+}
+.cdr-text--heading-serif-strong-800 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.016rem;
+    font-size: 3.2rem;
+    line-height: 3.6rem;
+}
+.cdr-text--heading-serif-strong-900 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.032rem;
+    font-size: 3.6rem;
+    line-height: 4.4rem;
+}
+.cdr-text--heading-serif-strong-1000 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.032rem;
+    font-size: 4.2rem;
+    line-height: 5rem;
+}
+.cdr-text--heading-serif-strong-1100 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.032rem;
+    font-size: 4.8rem;
+    line-height: 5.6rem;
+}
+.cdr-text--heading-serif-strong-1200 {
+    font-family: Stuart, Georgia, serif;
+    font-style: normal;
+    font-weight: 600;
+    letter-spacing: -0.032rem;
+    font-size: 5.4rem;
+    line-height: 6.4rem;
+}
+.cdr-text--subheading-sans-300 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.6rem;
+    line-height: 2rem;
+}
+.cdr-text--subheading-sans-400 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: 0;
+    font-size: 1.8rem;
+    line-height: 2.4rem;
+}
+.cdr-text--subheading-sans-500 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 2rem;
+    line-height: 2.6rem;
+}
+.cdr-text--subheading-sans-600 {
+    font-family: Graphik, "Helvetica Neue", sans-serif;
+    font-style: normal;
+    font-weight: 500;
+    letter-spacing: -0.016rem;
+    font-size: 2.4rem;
+    line-height: 3rem;
+}
+@media (min-width: 0) and (max-width: 767px) {
+    .cdr-text--heading-serif-800\@xs {
+        font-family: Stuart, Georgia, serif;
+        font-style: normal;
+        font-weight: 500;
+        letter-spacing: -0.016rem;
+        font-size: 3.2rem;
+        line-height: 3.6rem;
+    }
+}

--- a/docs/.vuepress/theme/styles/theme.scss
+++ b/docs/.vuepress/theme/styles/theme.scss
@@ -1,6 +1,7 @@
 @import 'cdr-tokens';
 @import 'cdr-doc-tokens';
 @import 'examples.scss';
+@import 'deprecated-text.css';
 
 $side-navigation-logo-width: 162px;
 $side-navigation-width: 234px;
@@ -16,6 +17,10 @@ body {
 
 h1, h2, h3, h4, h5 {
   @include cdr-text-heading-serif-strong-600;
+}
+
+.sr-only {
+  @include cdr-display-sr-only;
 }
 
 .cdr-doc-page-shell {

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -206,7 +206,7 @@ CdrIcon by default adds `aria-hidden="true"` to the root SVG element. If your us
 
 ```
 <cdr-link href="/cart">
-  <icon-cart/><span class="cdr-display-sr-only">Go to cart page</span>
+  <icon-cart/><span class="sr-only">Go to cart page</span>
 </cdr-link>
 ```
 
@@ -224,12 +224,12 @@ For a button or link that contains text alongside an icon:
 
 ```
 <cdr-link>
-  <icon-check-lg/><span class="cdr-display-sr-only">Available For</span> Curbside Pickup
+  <icon-check-lg/><span class="sr-only">Available For</span> Curbside Pickup
 </cdr-link>
 
 
 <cdr-button>
-  <icon-check-lg/><span class="cdr-display-sr-only">Available for</span> Curbside Pickup
+  <icon-check-lg/><span class="sr-only">Available for</span> Curbside Pickup
 </cdr-button>
 ```
 
@@ -239,7 +239,7 @@ For an icon that exists outside of a link, button, or other actionable element, 
 
 ```
 <icon-virtual-outfitting/>
-<span class="cdr-display-sr-only">Virtual Outfitting</span>
+<span class="sr-only">Virtual Outfitting</span>
 ```
 
 - Pass a `<title>` and `<desc>` into the default slot of the icon component, each with unique ids. Add `role="img"` and `aria-labelledby="titleid descid"` to the icon component, replacing `titleid` and `descid` with the IDs that correspond to the `<title>` and `<desc>` elements. If using CdrIcon with custom SVG, make sure title is the first child element. Note that this approach should be used to visually describe the icon as if it were an image, and should not be used to add contextual description of the icon's meaning.

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -39,7 +39,7 @@
                 "description": "Toggles the modal title text, which comes from `label` or `labelSlot`."
               },
               {
-                "name": "ariaDescribedBy",
+                "name": "ariaDescribedby",
                 "type": "string",
                 "default": "'medium'",
                 "description": "Text for the `aria-describedby` attribute."
@@ -128,7 +128,7 @@
   label="Add to Cart"
   :opened="opened"
   @closed="opened = false"
-  aria-described-by="description"
+  aria-describedby="description"
 >
   <template v-slot:title>
     <cdr-text
@@ -168,7 +168,7 @@ When rendering multiple modals on a single page you can reduce your markup size 
   :opened="opened"
   :label="title"
   @closed="opened = false"
-  aria-described-by="description"
+  aria-describedby="description"
 >
   <template v-slot:title>
     <cdr-text
@@ -194,10 +194,10 @@ Ensure that usage of this component complies with accessibility guidelines:
 >Launch modal</cdr-button>
 ```
 
-- Set the `aria-described-by` prop to point to an element that describes what the modal does:
+- Set the `aria-describedby` prop to point to an element that describes what the modal does:
 
 ```vue
-  <cdr-modal aria-described-by="description" label="modal title">
+  <cdr-modal aria-describedby="description" label="modal title">
     <div id="description">
       modal content description
     </div>
@@ -293,7 +293,7 @@ Do not use `v-if` with CdrModal unless the component is wrapped with `keep-alive
     :opened="opened"
     label="Add to Cart"
     @closed="closed"
-    aria-described-by="description"
+    aria-describedby="description"
   >
     ...
   </cdr-modal>

--- a/docs/components/selects/README.md
+++ b/docs/components/selects/README.md
@@ -439,16 +439,18 @@ CdrSelect can be rendered with nested options using the `optgroup` tag.
 
 To ensure that the usage of Select component complies with the accessibility guidelines:
 + Always provide a label for each select control
-+ If hiding a label, use the `aria-label` attribute for the label contents
++ The `hide-label` property can be used to visually hide the label text while still leaving it available to screen readers
 
 When using the `aria-describedby`:
 + `aria-describedby` attribute does not override the select label
 + Use this attribute in addition to a label
 + Can be used to reference descriptions that appear as 'tooltips'
++ Content passed into the `helper-text` slot is automatically linked to the `aria-describedby` attribute
 
 This component has compliance with WCAG guidelines by:
 + Requiring a value for the `label` field
 + When hiding a label, the `aria-label` attribute is set to the `label` value
++ Links `helper-text` content to the input field using the `aria-describedby` attribute
 
 <hr>
 
@@ -515,12 +517,12 @@ Select components should be:
 
 ### Icon
 
-- Use icons to trigger a popover for hints or suggestions
+- Use icons to trigger a [popover](../popover) or [tooltip](../tooltip) for hints or suggestions
 - Reference Cedar's [icon guidelines](../icon/#guidelines) for additional information
 
 ### Link Text
 
-- Use a link when moving or navigating to another page or to a different portion of the same page
+- Use a link in the `info` slot when moving or navigating to another page or to a different portion of the same page
 - Use if navigating user to long or complex information
 - Reference the [Links](../links/) component article for more information
 
@@ -568,29 +570,5 @@ This component will bind any attribute that a [native HTML select element](https
 ## Component Variables
 
 <cdr-doc-comp-vars name="CdrSelect">Note that the <a href="../component-variables/#CdrLabelStandalone">cdr-label-standalone mixins</a> should be used for assembling the label element. </cdr-doc-comp-vars>
-
-## Usage
-
-The **CdrSelect** component requires `v-model` to bind the selected value to your data model, as well as a `label` for accessibility.
-
-```vue
-<cdr-select
-  label="Label Text"
-  v-model="selected"
->
-  <option value="1">
-    1
-  </option>
-  <option value="2">
-    2
-  </option>
-  <option value="3">
-    3
-  </option>
-  <option value="4">
-    4
-  </option>
-</cdr-select>
-```
 
 </cdr-doc-table-of-contents-shell>

--- a/docs/components/text/README.md
+++ b/docs/components/text/README.md
@@ -173,17 +173,7 @@
                 "type": "string",
                 "default": "'p'",
                 "description": "Sets valid HTML element tag."
-              },
-              {
-                "name": "modifier",
-                "type": "string",
-                "default": "N/A",
-                "alert": {
-                  "type": "deprecated",
-                  "description": "The modifier prop for CdrText is deprecated, @rei/cdr-tokens should be used to apply type styles instead"
-                },
-                "description": "Modifies the style variant for this component. see below tables for list of options. ",
-              },
+              }
             ],
             "slots": [
               {
@@ -218,7 +208,7 @@ Serif headings, set in REI Stuart, work best in larger sizes (cdr-text-heading-s
 
 ```html
 
-  <cdr-text modifier="heading-serif-1200">
+  <cdr-text class="cdr-text--heading-serif-1200">
     When you gear up, we give back
   </cdr-text>
 
@@ -247,7 +237,7 @@ Serif strong headings, set in REI Stuart with a greater font weight than [serif]
 
 ```html
 
-  <cdr-text modifier="heading-serif-strong-1200">
+  <cdr-text class="cdr-text--heading-serif-strong-1200">
     When you gear up, we give back
   </cdr-text>
 
@@ -277,7 +267,7 @@ Sans headings, set in Graphik, should play a supporting role to serif headings. 
 
 ```html
 
-  <cdr-text modifier="heading-sans-600">
+  <cdr-text class="cdr-text--heading-sans-600">
     When you gear up, we give back
   </cdr-text>
 
@@ -341,7 +331,7 @@ Cedar does not offer pre-styled responsive headings. Instead, construct responsi
 
 ```html
   <cdr-text
-    modifier="heading-serif-800@xs heading-serif-900">
+    class="cdr-text--heading-serif-800@xs heading-serif-900">
       When you gear up, we give back
   </cdr-text>
 ```
@@ -381,7 +371,7 @@ Sans-serif subheadings are set in Graphik. They are intended to be paired with s
 
 ```html
 
-  <cdr-text modifier="subheading-sans-600">
+  <cdr-text class="cdr-text--subheading-sans-600">
     When you gear up, we give back
   </cdr-text>
 
@@ -411,11 +401,10 @@ Serif headings should only accompanied by sans subheadings.
 
 ```html
   <cdr-text
-    modifier="heading-serif-strong-900">
+    class="cdr-text--heading-serif-strong-900">
       When you gear up, we give back
       <cdr-text
-       modifier="subheading-sans-500"
-       class="stack">
+       class="cdr-text--subheading-sans-500 stack">
        Treat yourself to sweet gear
        </cdr-text>
   </cdr-text>
@@ -451,11 +440,10 @@ Sans headings also work best with sans subheadings.
 
 ```html
   <cdr-text
-    modifier="heading-sans-600">
+    class="cdr-text--heading-sans-600">
       When you gear up, we give back
       <cdr-text
-       modifier="subheading-sans-300"
-       class="stack">
+       class="cdr-text--subheading-sans-300 stack">
        Treat yourself to sweet gear
        </cdr-text>
   </cdr-text>
@@ -497,7 +485,7 @@ Body styles work best for long-form copy like articles, customer reviews, or leg
 
 ```html
 
-  <cdr-text modifier="body-500">
+  <cdr-text class="cdr-text--body-500">
     Cross-country skiing (sometimes called classic skiing) encompasses several styles, from touring or racing on groomed ski tracks to gliding through deep backcountry snow.
   </cdr-text>
 
@@ -526,7 +514,7 @@ Body strong is also intended for long-form copy but should be used minimally. Us
 
 ```html
 
-  <cdr-text modifier="body-strong-500">
+  <cdr-text class="cdr-text--body-strong-500">
     Cross-country skiing (sometimes called classic skiing) encompasses several styles, from touring or racing on groomed ski tracks to gliding through deep backcountry snow.
   </cdr-text>
 
@@ -596,7 +584,6 @@ Body styles include a set of strong options: `cdr-text-body-strong-500`, `cdr-te
 
 Utility styles are used to communicate  functionality or descriptive information. Shorter content is a good candidate for the more condensed and compact utility styling. Utility styles should not be replaced with headings. While headings help group and categorize content, utility styles help to label elements or give users information on how to take action. Cedar utility styles are available in both serif and [sans serif](https://rei.github.io/rei-cedar-docs/foundation/typography/#graphik) options. Additionally, each utility style has a strong option.
 
-By default, text within a `cdr-container` will display as `cdr-text-utility-300`.
 
 ### Serif
 Utility serif styles should be used when additional brand emphasis is needed.
@@ -605,7 +592,7 @@ Utility serif styles should be used when additional brand emphasis is needed.
 
 ```html
 
-  <cdr-text modifier="utility-serif-800">
+  <cdr-text class="cdr-text--utility-serif-800">
     Mon–Fri, 7am–5pm PT
   </cdr-text>
 
@@ -633,7 +620,7 @@ Utility serif strong styles should be used when additional emphasis is needed ov
 
 ```html
 
-  <cdr-text modifier="utility-serif-strong-800">
+  <cdr-text class="cdr-text--utility-serif-strong-800">
     Mon–Fri, 7am–5pm PT
   </cdr-text>
 
@@ -661,7 +648,7 @@ Utility sans styles typically make up the majority of utility styles used on a g
 
 ```html
 
-  <cdr-text modifier="utility-sans-800">
+  <cdr-text class="cdr-text--utility-sans-800">
     Mon–Fri, 7am–5pm PT
   </cdr-text>
 
@@ -689,7 +676,7 @@ Utility sans styles should be used when additional emphasis is needed.
 
 ```html
 
-  <cdr-text modifier="utility-sans-strong-800">
+  <cdr-text class="cdr-text--utility-sans-strong-800">
     Mon–Fri, 7am–5pm PT
   </cdr-text>
 
@@ -724,7 +711,7 @@ Eyebrows introduce a topic or show how an item is categorized. Content tags or c
 
 ```html
 
-  <cdr-text modifier="eyebrow-100">
+  <cdr-text class="cdr-text--eyebrow-100">
     Hiking, backpacking
   </cdr-text>
 
@@ -760,11 +747,11 @@ In addition to the specific type options listed above, we have provided two gene
 
 ```html
 
-  <cdr-text modifier="body-300">
+  <cdr-text class="cdr-text--body-300">
     REI Co-op’s Trailsmith line was featured in  
     <cdr-text
     tag="em"
-    modifier="italic">
+    class="cdr-text--italic">
     Field & Stream’s
     </cdr-text>
     “10 Best Pants for Working Outside”
@@ -800,11 +787,11 @@ In addition to the specific type options listed above, we have provided two gene
 
 ```html
 
-  <cdr-text modifier="body-300">
+  <cdr-text class="cdr-text--body-300">
     This trip is rated as
     <cdr-text
     tag="strong"
-    modifier="strong">
+    class="cdr-text--strong">
     Vigorous [4]
     </cdr-text>.
   </cdr-text>
@@ -884,7 +871,7 @@ For more information about design tokens and a complete list of tokens available
 The **CdrText** component allows for styling any HTML element with available text styles. Visual style and semantic meaning are managed independently by providing:
 
 - A `tag` property to control which type of element is rendered
-- Styling which can be applied ith a custom CSS class and a text mixin
+- Styling which can be applied with a custom CSS class and a text mixin
 
 This method decouples the semantic meaning of a heading level from the visual representation.
 

--- a/docs/patterns/update-and-loading-notifications/README.md
+++ b/docs/patterns/update-and-loading-notifications/README.md
@@ -23,7 +23,7 @@ Update and Loading Notifications update existing inline page content.
 They inform users of advisory information that enhances the site experience such as quantity updates or busy states.
 Additionally, These notifications often only update a specific part of an inline content section.
 
-It is important to grasp that many visual transitions are actually update notifications and should provide contextual information to our users. 
+It is important to grasp that many visual transitions are actually update notifications and should provide contextual information to our users.
 This can be added in the form of screen reader only text, though consider if the action without context will create any cognitive dissonance for our visual users.
 Remember to create sufficient Visual feedback as many update notifications are unassociated triggering action.
 
@@ -113,16 +113,16 @@ The Update Notification Content Container wraps both the element being updated a
     <!-- EXAMPLE: while stable -->
     <div aria-live="polite" role="region" aria-labelledby="shopping-cart">
       4
-      <span class="cdr-display-sr-only">items in your cart</span>
+      <span class="sr-only">items in your cart</span>
     </div>
     ```
     ```html
     <!-- EXAMPLE: when updated -->
     <div role="status" aria-live="polite" role="region" aria-labelledby="shopping-cart">
 
-      <span class="cdr-display-sr-only">there are now</span>
-      5 
-      <span class="cdr-display-sr-only">items in your cart</span>
+      <span class="sr-only">there are now</span>
+      5
+      <span class="sr-only">items in your cart</span>
     </div>
     ```
 
@@ -143,7 +143,7 @@ The Update Notification Content Container wraps both the element being updated a
 #### loading status
 <cdr-img :src="$withBase('/notifications/loadingNotification.png')" alt="Diagram of loading animation annotating the list below" width="600px"/>
 
-Update Notifications will often be used to represent loading icons or submitting buttons. These types of Update notifications 
+Update Notifications will often be used to represent loading icons or submitting buttons. These types of Update notifications
 - **Should**
   - Define pre-existing page sections where content may be updated as a WAI-ARIA live region.
   - Use the `aria-busy` attribute to indicate an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.
@@ -196,8 +196,8 @@ date content in locations unrelated to the action which caused the notification 
         <cdr-caption
         summary="After a user presses the Add to Cart button, the button grays out or changes to a loading icon, additionally, assistive technology should inform users of the busy state. For more information review the loading notification section above"/>
       </figcaption>
-    </figure> 
-  
+    </figure>
+
   </li>
   <li>
     <figure>

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -111,8 +111,7 @@ In order to distinguish generic background colors like primary and secondary fro
 
 ### CdrModal Aria Describedby
 
-The `aria-describedby` property on CdrModal has been updated to use the correct casing in order to match the default HTML aria attribute
-
+The `aria-describedby` property on CdrModal has been updated to use the correct casing in order to match the default HTML aria attribute. To address this change, in any CdrModal instance replace `ariaDescribedBy` with `ariaDescribedby` or `aria-described-by` with `aria-describedby`.
 
 ### Removals
 


### PR DESCRIPTION
- updates some release notes
- fixes aria-describedby info on mondal page
- fix homepage layout
- replace remaining utility classes
- load deprecated text utilities for use in text examples, switch text examples from `modifier` to `class`. Long term we should move to authoring examples as vue components, until then there's no easy way to handle this without just defining a class for every point in the text scale