### PR TITLE
More aria

### DIFF
--- a/docs/.vuepress/theme/NavLinks.vue
+++ b/docs/.vuepress/theme/NavLinks.vue
@@ -11,7 +11,7 @@
         :opened="navGroup[index]"
         @accordion-toggle="navToggle(index)"
       >
-        <template v-slot:label>
+        <template #label>
           {{ item.text }}
         </template>
         <ul class="nav-dropdown cdr-doc-side-navigation__child-links">

--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -135,7 +135,7 @@ Section borders expand to full width of container.
     :opened="default1"
     @accordion-toggle="default1 = !default1"
   >
-    <template v-slot:label>
+    <template #label>
       How do I find my member number?
     </template>
     <cdr-text tag="p">
@@ -149,7 +149,7 @@ Section borders expand to full width of container.
     :opened="default2"
     @accordion-toggle="default2 = !default2"  
   >
-    <template v-slot:label>
+    <template #label>
       Does every member get an Annual Dividend?
     </template>
     <cdr-text tag="p">
@@ -164,7 +164,7 @@ Section borders expand to full width of container.
     :opened="default3"
     @accordion-toggle="default3 = !default3"
   >
-    <template v-slot:label>
+    <template #label>
       When does my dividend expire?
     </template>
     <cdr-text tag="p">
@@ -192,7 +192,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
     :opened="compact1"
     @accordion-toggle="compact1 = !compact1"
   >
-    <template v-slot:label>
+    <template #label>
       Why buy used gear?
     </template>
     <cdr-text tag="p">
@@ -207,7 +207,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
     :opened="compact2"
     @accordion-toggle="compact2 = !compact2"
   >
-    <template v-slot:label>
+    <template #label>
       What's your cancellation policy?
     </template>
     <cdr-text tag="p">
@@ -222,7 +222,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
     :opened="compact3"
     @accordion-toggle="compact3 = !compact3"
   >
-    <template v-slot:label>
+    <template #label>
       When will my order arrive?
     </template>
     <cdr-text tag="p">
@@ -250,7 +250,7 @@ Border aligns to the title text and expand/collapse icon.
     :opened="borderAligned1"
     @accordion-toggle="borderAligned1 = !borderAligned1"
   >
-    <template v-slot:label>
+    <template #label>
       How long have you been in business?
     </template>
     <cdr-text tag="p">
@@ -266,7 +266,7 @@ Border aligns to the title text and expand/collapse icon.
     :opened="borderAligned2"
     @accordion-toggle="borderAligned2 = !borderAligned2"
   >
-    <template v-slot:label>
+    <template #label>
       What kinds of trips are offered?
     </template>
     <cdr-text tag="p">
@@ -283,7 +283,7 @@ Border aligns to the title text and expand/collapse icon.
     :opened="borderAligned3"
     @accordion-toggle="borderAligned3 = !borderAligned3"
   >
-    <template v-slot:label>
+    <template #label>
       How do I know what each trip is like?
     </template>
     <cdr-text tag="p">
@@ -311,7 +311,7 @@ The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion
     :opened="unwrap1"
     @accordion-toggle="unwrap1 = !unwrap1"
   >
-    <template v-slot:label>
+    <template #label>
       How do I find my member number?
     </template>
     <cdr-text tag="p">
@@ -325,7 +325,7 @@ The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion
     :opened="unwrap2"
     @accordion-toggle="unwrap2 = !unwrap2"  
   >
-    <template v-slot:label>
+    <template #label>
       Does every member get an Annual Dividend?
     </template>
     <cdr-text tag="p">
@@ -340,7 +340,7 @@ The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion
     :opened="unwrap3"
     @accordion-toggle="unwrap3 = !unwrap3"
   >
-    <template v-slot:label>
+    <template #label>
       When does my dividend expire?
     </template>
     <cdr-text tag="p">
@@ -460,7 +460,7 @@ CdrAccordion emits an event when its button is clicked. Use an event listener to
     :opened="opened"
     @accordion-toggle="opened = !opened"
   >
-    <template v-slot:label>
+    <template #label>
       Click me to show content!
     </template>
       This content is revealed when the accordion is opened.
@@ -496,7 +496,7 @@ Creating groups can be useful if, for instance, you wanted to close the other ac
     :key="item.id"
     @accordion-toggle="updateGroup(index)"
   >
-    <template v-slot:label>
+    <template #label>
       {{ item.label }}
     </template>
     {{ item.content }}

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -255,7 +255,7 @@ Pair an icon with text to improve recognition about an object or action.
     <cdr-button
       modifier="secondary"
     >
-      <template v-slot:icon-left>
+      <template #icon-left>
         <icon-play-stroke
           inherit-color
         />
@@ -266,7 +266,7 @@ Pair an icon with text to improve recognition about an object or action.
       modifier="secondary"
       disabled
     >
-      <template v-slot:icon-left>
+      <template #icon-left>
         <icon-play-stroke
           inherit-color
         />
@@ -290,7 +290,7 @@ Use icons to visually communicate an object or action in a limited space. Includ
       :icon-only="true"
       aria-label="More information about icon"
     >
-      <template v-slot:icon>
+      <template #icon>
         <icon-question-fill inherit-color />
       </template>
     </cdr-button>
@@ -312,7 +312,7 @@ Use `with-background` property in conjunction with the `icon-only` property to m
       :with-background="true"
       aria-label="More information about icon"
     >
-      <template v-slot:icon>
+      <template #icon>
         <icon-account-profile />
       </template>
     </cdr-button>

--- a/docs/components/chips/README.md
+++ b/docs/components/chips/README.md
@@ -236,8 +236,8 @@ Use `icon-left` or `icon-right` slots to pass icons into a chip. Place the X rem
 
 ```html
 <div>
-  <cdr-chip>Text and icon left <template v-slot:icon-left><icon-heart-stroke inherit-color size="small"/></template></cdr-chip>
-  <cdr-chip>Text and icon right <template v-slot:icon-right><icon-check-lg size="small" inherit-color/></template></cdr-chip>
+  <cdr-chip>Text and icon left <template #icon-left><icon-heart-stroke inherit-color size="small"/></template></cdr-chip>
+  <cdr-chip>Text and icon right <template #icon-right><icon-check-lg size="small" inherit-color/></template></cdr-chip>
 </div>
 ```
 </cdr-doc-example-code-pair>
@@ -257,14 +257,14 @@ For chips that toggle a single selection on and off, use the click event and d
     @click="toggle"
     :aria-pressed="toggled ? 'true' : 'false'"
   >
-    <template v-slot:icon-left>
+    <template #icon-left>
       <icon-heart-stroke
         size="small"
         inherit-color
         v-if="!toggled"
       />
     </template>
-    <template v-slot:icon-left>
+    <template #icon-left>
       <icon-heart-fill
         size="small"
         inherit-color
@@ -288,7 +288,7 @@ Filter chips add a visual representation of user selected filters. Filter chips 
 ```html
 <div>
   <cdr-checkbox v-model="filtered" id="filter-checkbox" @change="updateFilter">Add Filter</cdr-checkbox>
-  <cdr-chip v-if="filtered" @click="updateFilter" aria-controls="filter-checkbox" aria-pressed="true"> Remove filter <template v-slot:icon-right><icon-x-lg size="small" /></template></cdr-chip>
+  <cdr-chip v-if="filtered" @click="updateFilter" aria-controls="filter-checkbox" aria-pressed="true"> Remove filter <template #icon-right><icon-x-lg size="small" /></template></cdr-chip>
 </div>
 ```
 </cdr-doc-example-code-pair>

--- a/docs/components/form-group/README.md
+++ b/docs/components/form-group/README.md
@@ -145,7 +145,7 @@ Rather than passing a `label` prop, the label element can be customized using th
 
 ```html
 <cdr-form-group>
-  <template v-slot:label>
+  <template #label>
     <cdr-text style="font-size: 24px;">Optional Label Slot Override</cdr-text>
   </template>
   <cdr-checkbox

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -371,7 +371,7 @@ Error messaging will override helper text rendered in the bottom position.
   :error="modelError"
   @blur="validateInput"
 >
-  <template v-slot:helper-text-bottom>
+  <template #helper-text-bottom>
     Must be 4 or less characters
   </template>
 </cdr-input>
@@ -428,7 +428,7 @@ Input field with link text on right. The link should describe it's relationship 
   :background="backgroundColor"
   label="Input label"
 >
-  <template v-slot:info>
+  <template #info>
     <cdr-link href="#" modifier="standalone">Information link</cdr-link>
   </template>
 </cdr-input>
@@ -448,7 +448,7 @@ Input field with icon wrapped in an actionable element outside the input field o
   :background="backgroundColor"
   label="Input label"
 >
-  <template v-slot:info-action>
+  <template #info-action>
     <cdr-link tag="button">
       <icon-information-fill
         inherit-color
@@ -472,7 +472,7 @@ Input field with helper or hint text below the input field. If the input is in a
   :background="backgroundColor"
   label="Input label"
 >
-  <template v-slot:helper-text-bottom>
+  <template #helper-text-bottom>
     Helper or additional text
   </template>
 </cdr-input>
@@ -492,7 +492,7 @@ Input field with helper or hint text rendered above the input field. Helper text
   :background="backgroundColor"
   label="Input label"
 >
-  <template v-slot:helper-text-top>
+  <template #helper-text-top>
     Helper or additional text
   </template>
 </cdr-input>
@@ -512,7 +512,7 @@ Input field with icon inserted into the input field on left. Icon is decorative 
   :background="backgroundColor"
   label="Input label"
 >
-  <template v-slot:pre-icon>
+  <template #pre-icon>
     <icon-location-pin-stroke inherit-color />
   </template>
 </cdr-input>
@@ -532,7 +532,7 @@ Input field with icon inserted into the input field on right. Icon is decorative
   :background="backgroundColor"
   label="Input label"
 >
-  <template v-slot:post-icon>
+  <template #post-icon>
     <icon-credit-card
       inherit-color
       class="cdr-button__icon"
@@ -558,9 +558,9 @@ Input field with icon buttons inserted to the right. Up to 2 buttons can be pass
     label="Input label"
 
   >
-    <template v-slot:post-icon>
+    <template #post-icon>
       <cdr-tooltip class="cdr-input__button" id="input-tooltip">
-        <template v-slot:trigger>
+        <template #trigger>
           <cdr-button
             :icon-only="true"
           >
@@ -590,7 +590,7 @@ Input field with icon buttons inserted to the right. Up to 2 buttons can be pass
 
     size="large"
   >
-    <template v-slot:post-icon>
+    <template #post-icon>
       <cdr-button
         :icon-only="true"
         size="large"

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -172,7 +172,7 @@
                 "name": "required",
                 "type": "boolean",
                 "default": "false",
-                "description": "Sets the field to required and displays an asterisk next to the input label."
+                "description": "Sets aria-required on the input field and displays an asterisk next to the input label."
               },
               {
                 "name": "optional",

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -130,7 +130,7 @@
   @closed="opened = false"
   aria-describedby="description"
 >
-  <template v-slot:title>
+  <template #title>
     <cdr-text
       tag="h3"
       class="title-header"
@@ -170,7 +170,7 @@ When rendering multiple modals on a single page you can reduce your markup size 
   @closed="opened = false"
   aria-describedby="description"
 >
-  <template v-slot:title>
+  <template #title>
     <cdr-text
       tag="h3"
       class="title-header"
@@ -265,7 +265,7 @@ If the `title` slot is left empty, the `label` prop will be rendered as the titl
 When using the `label` slot, add CdrText to use the appropriate header styles.
 
 ```vue{3,4}
-<template v-slot:title>
+<template #title>
   <cdr-text
     tag="h1"
     class="custom-text-class"

--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -124,7 +124,7 @@ CdrPopover is a wrapper component that accepts a trigger element and popover con
 
 ```html
 <cdr-popover id="popover-example" position="top">
-  <template v-slot:trigger>
+  <template #trigger>
     <cdr-button>
       Click me
     </cdr-button>

--- a/docs/components/radio/README.md
+++ b/docs/components/radio/README.md
@@ -157,7 +157,7 @@ Default and standard spacing for radio buttons.
 <div>
   <cdr-form-group>
 
-    <template v-slot:label>
+    <template #label>
       <span id="legend-1">Default Radio Example</span>
     </template>
     <cdr-radio
@@ -202,7 +202,7 @@ Different sizing for radio buttons.
 <div>
   <cdr-form-group>
 
-    <template v-slot:label>
+    <template #label>
       <span id="legend-2">Radio Size Example</span>
     </template>
 
@@ -250,7 +250,7 @@ Custom styles for radio buttons.
 <div>
   <cdr-form-group>
 
-    <template v-slot:label>
+    <template #label>
       <span id="legend-3">Custom Radio Example</span>
     </template>
     <cdr-radio

--- a/docs/components/selects/README.md
+++ b/docs/components/selects/README.md
@@ -263,7 +263,7 @@ Select control with link text on right.
   prompt="Prompt text"
   :options="defaultOptions"
 >
-  <template v-slot:info>
+  <template #info>
     <cdr-link
       href="#/"
       modifier="standalone"
@@ -281,7 +281,7 @@ Select control with link text on right.
   :options="defaultOptions"
   disabled
 >
-  <template v-slot:info>
+  <template #info>
     <cdr-link
       href="#/"
       modifier="standalone"
@@ -309,7 +309,7 @@ Select control with icon outside select field on right.
   prompt="Prompt text"
   :options="defaultOptions"
 >
-  <template v-slot:info-action>
+  <template #info-action>
     <cdr-link tag="button">
       <icon-information-fill/>
     </cdr-link>
@@ -334,7 +334,7 @@ Input field with helper or hint text below the input field.
   prompt="Prompt text"
   :options="defaultOptions"
 >
-  <template v-slot:helper-text>
+  <template #helper-text>
     This is helper text.
   </template>
 </cdr-select>
@@ -347,7 +347,7 @@ Input field with helper or hint text below the input field.
   :options="defaultOptions"
   disabled
 >
-  <template v-slot:helper-text>
+  <template #helper-text>
     This is helper text.
   </template>
 </cdr-select>

--- a/docs/components/selects/README.md
+++ b/docs/components/selects/README.md
@@ -101,7 +101,7 @@
                 "name": "required",
                 "type": "boolean",
                 "default": "false",
-                "description": "Sets the field to required and displays an asterisk next to the select label"
+                "description": "Sets aria-required on the input field and displays an asterisk next to the select label"
               },
               {
                 "name": "optional",

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -123,9 +123,9 @@ CdrTooltip is a wrapper component that accepts a trigger element and tooltip con
 
 ```html
 <cdr-tooltip id="tooltip-example" position="top">
-  <template v-slot:trigger>
+  <template #trigger>
     <cdr-button :icon-only="true" :with-background="true">
-      <template v-slot:icon>
+      <template #icon>
         <icon-information-stroke/>
       </template>
     </cdr-button>
@@ -159,7 +159,7 @@ CdrTooltip can also be controlled programmatically using the `open` prop. Howeve
     :with-background="true"
     aria-describedby="tooltip-custom-example"
   >
-    <template v-slot:icon>
+    <template #icon>
       <icon-information-stroke/>
     </template>
   </cdr-button>

--- a/docs/getting-started/as-a-developer/README.md
+++ b/docs/getting-started/as-a-developer/README.md
@@ -229,9 +229,9 @@ Adding content to a component that has named slots
 
 ```html
 <my-component>
-  <template v-slot:header>I'm content in the header slot</template>
+  <template #header>I'm content in the header slot</template>
 
-  <template v-slot:footer>I'm content in the footer slot</template>
+  <template #footer>I'm content in the footer slot</template>
 </my-component>
 ```
 
@@ -239,7 +239,7 @@ Adding content to a scoped slot
 
 ```html
 <my-component>
-  <template v-slot:name-of-the-slot="scopeObject">
+  <template #name-of-the-slot="scopeObject">
     {{scopeObject.content}} {{scopeObject.someAttribute}}
   </template>
 </my-component>

--- a/docs/patterns/alerts/README.md
+++ b/docs/patterns/alerts/README.md
@@ -96,7 +96,7 @@ They appear over the interface and block further interactions until an action is
   aria-described-by="description"
   role="alertdialog"
 >
-  <template v-slot:title>
+  <template #title>
     <cdr-text
       tag="h3"
       class="title-header"

--- a/docs/patterns/forms/README.md
+++ b/docs/patterns/forms/README.md
@@ -87,7 +87,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   :error="errorMessage"
   @blur="validate"
 >
-  <template v-slot:helper-text-top>
+  <template #helper-text-top>
     To call if there's an issue with your order.
   </template>
 </cdr-input>
@@ -127,7 +127,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
     :optional="true"
     class="form-space"
   >
-    <template v-slot:helper-text-top>
+    <template #helper-text-top>
       Is there another name you prefer to go by?
     </template>
   </cdr-input>
@@ -256,7 +256,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   style="width: 160px;"
   @input="restrictInput"
 >
-  <template v-slot:helper-text-top>
+  <template #helper-text-top>
     Three digit number on the back.
   </template>
 </cdr-input>
@@ -285,7 +285,7 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   style="width: 160px;"
   :numeric="true"
 >
-  <template v-slot:helper-text-top>
+  <template #helper-text-top>
     Use MM/YY format.
   </template>
 </cdr-input>
@@ -339,9 +339,9 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   <option value="male">Female</option>
   <option value="female">Male</option>
   <option value="describe">Prefer to describe</option>
-  <template v-slot:info>
+  <template #info>
     <cdr-popover id="popover-example" position="top">
-      <template v-slot:trigger>
+      <template #trigger>
         <cdr-link tag="button">
           <icon-information-stroke inherit-color/>
         </cdr-link>

--- a/docs/release-notes/fall-2019/README.md
+++ b/docs/release-notes/fall-2019/README.md
@@ -151,7 +151,7 @@ After:
   :opened="opened"
   @accordion-toggle="opened = !opened"
 >
-  <template v-slot:label>
+  <template #label>
     How do I find my member number?
   </template>
   <cdr-text>

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -22,8 +22,7 @@
 |--------------|---------|
 | `@rei/cedar` | ^9.x.x |
 | `@rei/cdr-tokens` | ^9.x.x |
-| `@rei/cdr-component-variables` | ^x.x.x |
-| `@rei/cedar-icons` | ^x.x.x |
+| `@rei/cdr-component-variables` | ^7.x.x |
 
 - If your project depends on any shared component packages (i.e, FEDPACK, FEDCOMP, FEDPAGES), you will want to update those packages to the new version of Cedar before updating your micro-site.
 
@@ -50,6 +49,7 @@ If a CdrInput receives either `type="number"` or `:numeric="true"`, it will set 
 We have made a number of improvements to our form components to make them more accessible and consistent:
 
 - Default `autocorrect`, `autocapitalize`, and `spellcheck` attributes on CdrInput are now set automatically to make input more consistent across different browsers and devices. These attributes can be overridden if needed.
+- CdrInput and CdrSelect now set `aria-required` instead of the `required` attribute on the HTML input element when the `required` property is passed in. Because validation is handled programmatically `aria-required` results in a more consistent user experience across browsers than `required` does.
 - If a `helper-text` slot is used in conjunction with CdrInput or CdrSelect that helper text element is now automatically linked to the input field using the `aria-describedby` attribute. The `aria-describedby` attribute can still be used to link additional elements to the input if needed.
 - If the `error` property is used on a CdrInput, CdrSelect, or CdrFormGroup component the input field gets marked as `aria-invalid="true"` and the error message is linked to the input field using the `aria-errormessage` attribute.
 

--- a/docs/release-notes/spring-2021/README.md
+++ b/docs/release-notes/spring-2021/README.md
@@ -75,18 +75,18 @@ CdrBreadcrumb and CdrPagination both allow for passing in a scoped slot for rend
 
 ### Vue 3: Update Slot Syntax
 
-Vue 2.6 introduced a new syntax for passing slot content into components. The old syntax is removed from Vue 3 and we recommend updating your codebase to make use of the new slot syntax to simplify the upgrade process in the future. Note that the new `v-slot` syntax can only be used on a `template` tag, however those additional `template` tags will not be included in the rendered HTML.
+Vue 2.6 introduced a new `v-slot` syntax for passing slot content into components. A pound sign `#` can be used as a shorthand for `v-slot:`, much like a colon `:` can be used as a shorthand for `v-bind`. The old syntax is removed from Vue 3 and we recommend updating your codebase to make use of the new slot syntax to simplify the upgrade process in the future. Note that the new `v-slot` or `#` syntax can only be used on a `template` tag, however those additional `template` tags will not be included in the rendered HTML.
 
 ```
 <!-- Named slots -->
 <span slot="slotname">old named slot syntax</span>
-<template v-slot:slotname>
+<template #slotname>
   <span>new named slot syntax<span>
 </template>
 
 <!-- Scoped slots -->
 <template slot="slotname" slot-scope="scopeObject">old scoped slot syntax {{ scopeObject.name }}</template>
-<template v-slot:slotname="scopeObject">new scoped slot syntax {{ scopeObject.name }}</template>
+<template #slotname="scopeObject">new scoped slot syntax {{ scopeObject.name }}</template>
 ```
 
 The examples on this doc site have been updated to make use of the new syntax, see the [Vue documentation](https://vuejs.org/v2/guide/components-slots.html#Named-Slots) for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1288,9 +1288,9 @@
       "integrity": "sha512-feXbIfAGQfa3vXxRZq43CL1+8RVr7GRPUEYR42ZZzkILZazTZUwSiCgslhnC9kqOFplaxmdzh1gWqRbuPlbfgw=="
     },
     "@rei/cedar": {
-      "version": "9.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-9.0.0-beta.2.tgz",
-      "integrity": "sha512-PCkJV4PAMf/M7Ianjm6bXGOyJmFr1QMhWLSpp10cgMuNPwMqIO1BKNi91L45s0t1Hvbe4C6UNyg9QKXz0lo5TQ==",
+      "version": "9.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-9.0.0-beta.3.tgz",
+      "integrity": "sha512-yIzY8vQcF09D8NO4ZSBfHMdzCJGwme8RrHf1EovBKPg/jqOSPK3mThUhss1Y66VqKaxjJih+B6xgKcf4RXFuFw==",
       "requires": {
         "@babel/runtime": "^7.14.0",
         "@babel/runtime-corejs3": "^7.14.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/runtime-corejs3": "^7.14.0",
     "@rei/cdr-component-variables": "^7.0.0-beta.1",
     "@rei/cdr-tokens": "^9.0.0-alpha.1",
-    "@rei/cedar": "^9.0.0-beta.2",
+    "@rei/cedar": "^9.0.0-beta.3",
     "throttle-debounce": "^3.0.0"
   },
   "browserslist": [


### PR DESCRIPTION
- pull in cedar beta, document required-> aria-required witch
- update `v-slot` to use `#` shorthand, as the latest eslint-plugin-vue throws a warning otherwise