### PR TITLE
added note to top of page

### DIFF
--- a/docs/icons/library/README.md
+++ b/docs/icons/library/README.md
@@ -29,5 +29,7 @@
 }
 ---
 
+Note that the icons shown on this page are for visual reference only. Icons can be found in the [Figma iconography library](https://www.figma.com/file/RuzW1gp60W1tahwD4m1uBc/Cedar-Iconography) and [Vue component](../../components/icon/) package.
+SVG icons can be downloaded [here](https://rei.github.io/cedar-icons/#/).
 
 <icon-page/>

--- a/docs/icons/library/README.md
+++ b/docs/icons/library/README.md
@@ -29,7 +29,9 @@
 }
 ---
 
-Note that the icons shown on this page are for visual reference only. Icons can be found in the [Figma iconography library](https://www.figma.com/file/RuzW1gp60W1tahwD4m1uBc/Cedar-Iconography) and [Vue component](../../components/icon/) package.
-SVG icons can be downloaded [here](https://rei.github.io/cedar-icons/#/).
+<cdr-doc-alert icon="info">
+  Note that the icons shown on this page are for visual reference only. Icons can be found in the [Figma iconography library](https://www.figma.com/file/RuzW1gp60W1tahwD4m1uBc/Cedar-Iconography) and [Vue component](../../components/icon/) package.
+  SVG icons can be downloaded [here](https://rei.github.io/cedar-icons/#/).
+</cdr-doc-alert>
 
 <icon-page/>

--- a/docs/icons/library/README.md
+++ b/docs/icons/library/README.md
@@ -29,9 +29,10 @@
 }
 ---
 
+
 <cdr-doc-alert icon="info">
-  Note that the icons shown on this page are for visual reference only. Icons can be found in the [Figma iconography library](https://www.figma.com/file/RuzW1gp60W1tahwD4m1uBc/Cedar-Iconography) and [Vue component](../../components/icon/) package.
-  SVG icons can be downloaded [here](https://rei.github.io/cedar-icons/#/).
+  <p>Note that the icons shown on this page are for visual reference only. Icons can be found in the <cdr-link href="https://www.figma.com/file/RuzW1gp60W1tahwD4m1uBc/Cedar-Iconography">Figma iconography library</cdr-link> and <cdr-link href="../../components/icon/">Vue component</cdr-link> package.
+  SVG icons can be downloaded <cdr-link href="https://rei.github.io/cedar-icons/#/">here</cdr-link>.</p>
 </cdr-doc-alert>
 
 <icon-page/>


### PR DESCRIPTION
Jay and Michael - I really wanted to include the note that this page is visual reference only and add a link to the SVG downloads. Figured to mention where designers and developers would find those icons - let me know if this is the right terminology and links to share.