### PR TITLE
Applying background color to in-paragraph code elements

### DIFF
--- a/docs/.vuepress/components/cdr-doc-table-of-contents-shell.vue
+++ b/docs/.vuepress/components/cdr-doc-table-of-contents-shell.vue
@@ -142,6 +142,10 @@ export default {
       a {
         @include cdr-link-base-mixin;
       }
+      p code {
+        background-color: $cdr-color-background-secondary;
+        padding: 0.2rem;
+      }
       h2 {
         @include cdr-text-heading-serif-strong-800;
       }


### PR DESCRIPTION
This just applies the secondary background behind `code` elements within `<p>` tags. 

<img width="998" alt="codestyle" src="https://user-images.githubusercontent.com/2114425/137787879-b7abfa15-778a-49a8-919e-23fb30700b48.png">


