### PR TITLE
Alt text updates to Radius page

### DIFF
--- a/docs/foundation/radius/README.md
+++ b/docs/foundation/radius/README.md
@@ -13,13 +13,13 @@
     {
       "image": "radius/radius-basics-1.png",
       "ratio": "4-3",
-      "alt": "A graphic showing a rectangle with rounded edges with a pointer cursor nearby.",
+      "alt": "A rectangle with rounded edges with a pointer cursor nearby.",
       "caption": "With few exceptions, interactive components are rounded."
     },
     {
       "image": "radius/radius-basics-2.png",
       "ratio": "4-3",
-      "alt": "A graphic showing a larger and smaller rectangle. The smaller rectangle has less rounded corners than the larger rectangle",
+      "alt": "A larger and smaller rectangle. The smaller rectangle has less rounded corners than the larger rectangle.",
       "caption": "An object's border radius should be proportional to its shortest side."
     },
   ],
@@ -27,13 +27,13 @@
     {
       "image": "radius/radius-nested-1.png",
       "ratio": "4-3",
-      "alt": "A graphic showing a larger rectangle with four smaller rectangles nested inside. The larger rectangle has a border radius as well as the nested rectangles",
+      "alt": "A large rectangle with four smaller rectangles nested inside. The larger rectangle has the same border type as the nested rectangles.",
       "caption": "A nested object should inherit its parent's border type: rounded or not rounded."
     },
     {
       "image": "radius/radius-nested-2.png",
       "ratio": "4-3",
-      "alt": "A graphic showing a larger rectangle with a smaller rectangle nested within. Both have a border radius. The nested rectangle has a smaller border radius than the larger one",
+      "alt": "A large rectangle with a smaller rectangle nested within. Both have a border radius but the nested rectangle's radius is smaller.",
       "caption": "The border radius of a nested, rounded object should be smaller than that of its parent."
     },
   ]
@@ -43,7 +43,7 @@
 <cdr-doc-table-of-contents-shell parentSelector='h2' childSelector='h3'>
 
 ## Overview
-<cdr-img :src="$withBase('/radius/radius-header.png')" ratio="16-9" alt="A graphic showing four nested rectangles against with rounded corners against a salmonberry colored background."/>
+<cdr-img :src="$withBase('/radius/radius-header.png')" ratio="16-9" alt="Four nested rectangles with rounded corners against a salmonberry colored background."/>
 
 ### Basics
 <two-column-captioned-images :examples="$page.frontmatter.basics"/>
@@ -56,7 +56,7 @@
 ### Tokenized options
 Cedar components include appropriate radii values applied by default. Use tokens to apply radii values to bespoke elements or containers.
 
-<cdr-img :src="$withBase('/radius/radius-tokens.png')" style="display:block; margin: 1em auto;" alt="A graphic showing four numbered shapes, each shape has softer rounded corners than the next. The fourth shape is by far the roundest"/>
+<cdr-img :src="$withBase('/radius/radius-tokens.png')" style="display:block; margin: 1em auto;" alt="Four numbered shapes, each shape with softer rounded corners than the next. The fourth shape is by far the roundest."/>
 1. Sharp: `cdr-radius-sharp` 
 2. Soft:  `cdr-radius-soft` 
 3. Softer:  `cdr-radius-softer` 


### PR DESCRIPTION
Updated image alt text for best practices. Edits include:

- Removing introductory clauses (e.g. "A graphic of") since screen readers already supply this info
- Adding periods to end sentences where needed
- Shortening to ~135 characters or less if needed
- Revising text for clarity if needed