### PR TITLE
Alt text edits for Spacing

### DIFF
--- a/docs/foundation/spacing/README.md
+++ b/docs/foundation/spacing/README.md
@@ -22,9 +22,9 @@ By design, Cedar elements are self contained and provide no spacing outside of t
 
 ### Box Model
 
-The Cedar spacing system is built around HTML’s foundational layout principle known as the **box model**. Every webpage is made of boxes and includes the ‘box within a box’ structure. The graphic below shows how the box model defines the structure and layout for all elements on a page.
+The Cedar spacing system is built around HTML’s foundational layout principle known as the **box model**. Every webpage is made of boxes and includes the ‘box within a box’ structure. The following graphic shows how the box model defines the structure and layout for all elements on a page.
 
-<cdr-img :src="$withBase('/layout/spacing-box-model.png')" alt="Box model structure of a webpage" />
+<cdr-img :src="$withBase('/layout/spacing-box-model.png')" alt="Box model structure with a larger box representing the margin around a smaller box representing content with its padding and border." />
 
 **Content:** In most cases, any content inside a box, text, or other boxes will wrap to its parent container’s width and push down to increase its parent container’s height dynamically.
 
@@ -41,15 +41,15 @@ Spacing is a unit of white space that pushes visual elements away from each othe
 
 The Cedar spacing system is based on 1.6rem or 16px units. There are 8 spacing values derived from a 16px base.
 
-<cdr-img class="cdr-doc-article-img" :src="$withBase('/layout/spacing-margin-horizontal.png')" alt="Horizontal spacing" />
+<cdr-img class="cdr-doc-article-img" :src="$withBase('/layout/spacing-margin-horizontal.png')" alt="Horizontal spacing example showing eight spacing values derived from a 16 pixel base. The narrowest spacing is two pixels and the widest is 64." />
 
-<cdr-img class="cdr-doc-article-img" :src="$withBase('/layout/spacing-margin-vertical.png')" alt="Vertical spacing" />
+<cdr-img class="cdr-doc-article-img" :src="$withBase('/layout/spacing-margin-vertical.png')" alt="Vertical spacing example showing eight spacing values derived from a 16 pixel base. The narrowest spacing is two pixels and the widest is 64." />
 
 ### Inset Padding
 
 An Inset padding is intended to provide consistent space within the content container. It defines how the typography, images, icons, and any content is spaced from the edge.
 
-<cdr-img :src="$withBase('/layout/spacing-inset-padding-sizes.png')" alt="Inset padding" />
+<cdr-img :src="$withBase('/layout/spacing-inset-padding-sizes.png')" alt="Eight boxes with text inside representing inset padding examples. The narrowest displays text closest to the box's edge, the widest displays text farthest from the edge." />
 
 Cedar provides three different variants for each inset token size:
 
@@ -58,7 +58,7 @@ Cedar provides three different variants for each inset token size:
 -  **Stretch:** Increases top and bottom spacing by 50%, resulting in a vertically expanded visual display
 
 
-<cdr-img :src="$withBase('/layout/spacing-inset-padding-variations.png')" alt="The three different types of inset padding" />
+<cdr-img :src="$withBase('/layout/spacing-inset-padding-variations.png')" alt="Three boxes with text inside displaying Cedar's inset padding variations, squish, default, and stretch." />
 
 ### Breakpoints
 
@@ -68,7 +68,7 @@ Like text size and other dimensions, Spacing and Inset can change based on scree
 
 Spacing and Insets should be combined to create compositions.
 
-<cdr-img :src="$withBase('/layout/spacing-redline-example.png')" alt="An example of combined Spacing and Insets" />
+<cdr-img :src="$withBase('/layout/spacing-redline-example.png')" alt="A box with multiple text areas combining spacing and insets to separate the text and provide breakpoint boundaries." />
 
 ## Usage Overview
 


### PR DESCRIPTION
Edits for alt text best practices. Edits include:

- Adding additional description for more specificity

Also one small edit to page copy, removing the word "below" for accessibility writing best practices. 