### PR TITLE
adding aria-label to icon only button

### DIFF
--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -412,8 +412,8 @@ Use the `type="number"` attribute only for input fields that reference a numeric
 
 ```html
 <div>
-  <cdr-button :icon-only="true" :with-background="true" @click="decrement" aria-label="Decrement counter" :disabled="decrementDisabled">
-    <icon-minus-lg/>
+  <cdr-button :icon-only="true" :with-background="true" @click="decrement" :disabled="decrementDisabled">
+    <icon-minus-lg aria-label="Decrement counter"/>
   </cdr-button>
   <cdr-input
     v-model="defaultModel"
@@ -422,8 +422,8 @@ Use the `type="number"` attribute only for input fields that reference a numeric
     type="number"
     style="display: inline-block; width: 160px;"
   />
-  <cdr-button :icon-only="true" :with-background="true" @click="increment" aria-label="Increment counter">
-    <icon-plus-lg/>
+  <cdr-button :icon-only="true" :with-background="true" @click="increment" >
+    <icon-plus-lg aria-label="Increment counter"/>
   </cdr-button>
 </div>
 ```
@@ -468,7 +468,6 @@ Input field with icon wrapped in an actionable element outside the input field o
       tag="button"
       aria-label="An external link to more information">
       <icon-information-fill
-        title ="More information"
         inherit-color
       />
     </cdr-link>

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -125,9 +125,9 @@ CdrTooltip is a wrapper component that accepts a trigger element and tooltip con
 ```html
 <cdr-tooltip id="tooltip-example" position="top">
   <template #trigger>
-    <cdr-button :icon-only="true" :with-background="true">
+    <cdr-button :icon-only="true" :with-background="true" aria-label="Overview example: additional information">
       <template #icon>
-        <icon-information-stroke/>
+        <icon-information-stroke title="info icon"/>
       </template>
     </cdr-button>
   </template>
@@ -158,10 +158,11 @@ CdrTooltip can also be controlled programmatically using the `open` prop. Howeve
     @blur="open = false"
     :icon-only="true"
     :with-background="true"
+    aria-label="Custom Trigger example: additional information"
     aria-describedby="tooltip-custom-example"
   >
     <template #icon>
-      <icon-information-stroke/>
+      <icon-information-stroke title="info icon"/>
     </template>
   </cdr-button>
   <cdr-tooltip id="tooltip-custom-example" position="top" :open="open">

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -125,9 +125,9 @@ CdrTooltip is a wrapper component that accepts a trigger element and tooltip con
 ```html
 <cdr-tooltip id="tooltip-example" position="top">
   <template #trigger>
-    <cdr-button :icon-only="true" :with-background="true" aria-label="Overview example: additional information">
+    <cdr-button :icon-only="true" :with-background="true">
       <template #icon>
-        <icon-information-stroke title="info icon"/>
+        <icon-information-stroke aria-label="Overview example: additional information"/>
       </template>
     </cdr-button>
   </template>
@@ -158,11 +158,10 @@ CdrTooltip can also be controlled programmatically using the `open` prop. Howeve
     @blur="open = false"
     :icon-only="true"
     :with-background="true"
-    aria-label="Custom Trigger example: additional information"
     aria-describedby="tooltip-custom-example"
   >
     <template #icon>
-      <icon-information-stroke title="info icon"/>
+      <icon-information-stroke aria-label="Custom Trigger example: additional information"/>
     </template>
   </cdr-button>
   <cdr-tooltip id="tooltip-custom-example" position="top" :open="open">

--- a/docs/patterns/forms-input-types/README.md
+++ b/docs/patterns/forms-input-types/README.md
@@ -342,8 +342,8 @@ Cedar provides components for the basic HTML input elements: [CdrInput](../../co
   <template #info>
     <cdr-popover id="popover-example" position="top">
       <template #trigger>
-        <cdr-link tag="button" aria-label="Why we ask for gender">
-          <icon-information-stroke title="Additional information icon" inherit-color/>
+        <cdr-link tag="button" >
+          <icon-information-stroke aria-label="Additional information" inherit-color/>
         </cdr-link>
       </template>
       <div>


### PR DESCRIPTION
Would be great to get some component validation set up for missing attributes 
in this case an icon only button requires an aria-label- if we miss this in documenting the feature others are also... 