### PR TITLE
Rebecca larue patch 5

### DIFF
--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -461,7 +461,7 @@ The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 To ensure that usage of this component complies with accessibility guidelines:
 - Provide descriptive label for accordion header

--- a/docs/components/accordion/README.md
+++ b/docs/components/accordion/README.md
@@ -126,9 +126,9 @@
 ---
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
-## Default (Medium)
+### Default (Medium)
 
 Section borders expand to full width of container.
 
@@ -184,7 +184,7 @@ Section borders expand to full width of container.
 
 </cdr-doc-example-code-pair>
 
-## Compact (Small)
+### Compact (Small)
 
 Reduced spacing around title and content body. Also, smaller font sizes resulting in overall denser display of content.
 
@@ -242,7 +242,7 @@ Reduced spacing around title and content body. Also, smaller font sizes resultin
 
 </cdr-doc-example-code-pair>
 
-## Border Aligned
+### Border Aligned
 
 Border aligns to the title text and expand/collapse icon.
 
@@ -303,7 +303,7 @@ Border aligns to the title text and expand/collapse icon.
 
 </cdr-doc-example-code-pair>
 
-## Content Spacing
+### Content Spacing
 
 Optionally remove content spacing (css padding) from the accordion content for applications needing more design flexibility.
 
@@ -375,7 +375,8 @@ Optionally remove content spacing (css padding) from the accordion content for a
 ```
 
 </cdr-doc-example-code-pair>
-## Dynamic Accordions
+
+### Dynamic Accordions
 
 In order to render a dynamic list of accordions, for example using data retrieved from a back-end API, you will need to use `this.$set` or some other Vue method to make the array of accordion data reactive. This can also be used to avoid creating an individual data attribute for every accordion and instead track their state with an array of booleans.
 
@@ -404,7 +405,7 @@ In order to render a dynamic list of accordions, for example using data retrieve
 </cdr-doc-example-code-pair>
 
 
-## Unwrapped
+### Unwrapped
 
 The `unwrap` property of `CdrAccordionGroup` can be used to render the accordion content in an "unwrapped" state. This property accepts either a boolean toggle or a list of breakpoints.
 
@@ -476,26 +477,26 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Providing users more content within the same layout
 - Displaying content that is directly related, or supplemental, to the main subject of the page
 - Designing with limited vertical space and there is enough content to condense
 
-## Don't Use When
+### Don't Use When
 
 - Linking a title to another page. Instead, use [Links](../links/)
 - Designing with sparse content. Instead, use [Lists](../lists/)
 - Content is lengthy. Instead, use [Tabs](../tabs/)
 
-## The Basics
+### The Basics
 
 - Use on either light or dark backgrounds. Background color is provided for both
 - Content within accordions can include text, photos, graphics, or other components (i.e. links, buttons, tables)
 
-## Content
+### Content
 
 - Order the accordion titles by priority and importance
 - Keep titles short to avoid wrapping at smaller viewports
@@ -503,17 +504,17 @@ This component has compliance with WCAG guidelines by:
 - Use short titles for accordion labels to avoid wrapping
 - Always include a title, icon, and subsequent content for each section. All are required
 
-## Anatomy
+### Anatomy
 
 - Position interactive elements (i.e. Select, Button, Link) within the container far enough from the title area to avoid accidental collapsing
 
-## Behavior
+### Behavior
 
 - Entire title area is clickable, including icon and background
 - Never nest accordions within themselves
 
 
-### Show and Hide
+#### Show and Hide
 
 - Revealing the first accordion section is recommended
 - Other accordion sections are all hidden by default, however it is possible to specify that:
@@ -530,7 +531,7 @@ This component has compliance with WCAG guidelines by:
 <do-dont :examples="$page.frontmatter.titles" />
 
 
-## Responsiveness
+### Responsiveness
 
 - Accordion style can change variant based on breakpoint. Example: Default at MD/LG can change to Compact and Border-Aligned at XS/SM
 - Switching between the Tab component and the Accordion component is not supported in Cedar components library
@@ -538,27 +539,27 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <api-slot :slots-getting-started-link="true" />
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" :slots-getting-started-link="false" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Usage
+### Usage
 
 CdrAccordion emits an event when its button is clicked. Use an event listener to toggle the value of the opened prop to open or close the accordion.
 

--- a/docs/components/block-quote/README.md
+++ b/docs/components/block-quote/README.md
@@ -138,9 +138,9 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
-## Default (Medium)
+### Default (Medium)
 
 Default block quote can be used with the following HTML tags: `<p>`, `<div>`, `<aside>`. This is responsive with styles for XS breakpoint.
 
@@ -176,19 +176,19 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Highlighting valuable customer feedback
 - Encouraging a customer to try out an experience or product
 
-## Don't Use When
+### Don't Use When
 
 - Pulling a direct quote from an article. Instead, use [Pull Quote](../pull-quote/)
 - Displaying for a decorative treatment only
 
-## The Basics
+### The Basics
 
 Use a block quote for emphasizing content that has a close and significant relationship with the surrounding text and will help users to visually scan the page.
 
@@ -208,7 +208,7 @@ Provide a citation to the external source and if available, the URL address.
 
 <do-dont :examples="$page.frontmatter.citation" />
 
-## Content
+### Content
 
 To make the block quote content accessible, follow these rules:
 
@@ -220,18 +220,18 @@ To make the block quote content accessible, follow these rules:
 - For more information, see [REI Accessible Patterns: Quotes](https://confluence.rei.com/display/accessibility/Quote)
 
 
-## Responsiveness
+### Responsiveness
 
 When block quotes are displayed at XS breakpoint, the text will use a smaller font size.
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 

--- a/docs/components/breadcrumb/README.md
+++ b/docs/components/breadcrumb/README.md
@@ -180,7 +180,7 @@ Can be used to override the default link navigation behavior inside a breadcrumb
 </cdr-doc-example-code-pair>
 
 
-## Accessibility
+### Accessibility
 
 
 To ensure that usage of this component complies with accessibility guidelines:

--- a/docs/components/breadcrumb/README.md
+++ b/docs/components/breadcrumb/README.md
@@ -119,8 +119,9 @@
 ---
 
 <cdr-doc-table-of-contents-shell>
-# Overview
-## Truncated (Default)
+## Overview
+
+### Truncated (Default)
 
 Long breadcrumb path shortened to display the last 2 items with hidden links indicated by ellipsis.
 
@@ -158,7 +159,7 @@ Complete breadcrumb string with all items visible.
 
 </cdr-doc-example-code-pair>
 
-## Custom Navigation
+### Custom Navigation
 
 Can be used to override the default link navigation behavior inside a breadcrumb.
 
@@ -196,19 +197,19 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Helping users understand where they are within the site hierarchy
 - Providing a shortcut to explore similar products within common parent categories
 
-## Don’t Use When
+### Don’t Use When
 
 - Displaying a top-level page, such as a home or high-level category page
 - Linking to previous steps of a sequential process
 
-## The Basics
+### The Basics
 
 Breadcrumbs provide context and a sense of place. This is especially important on a small screen, where other orienting content isn’t visible.
 
@@ -219,7 +220,7 @@ Breadcrumbs provide context and a sense of place. This is especially important o
 - Avoid displaying breadcrumbs on non-white backgrounds
 - Refer to API documentation for how to customize breadcrumb truncation width
 
-## Content
+### Content
 - Always align breadcrumb labels with page names that are the destination of that breadcrumb
 - Incorporate keywords into page names and breadcrumbs to improve SEO
 - Align breadcrumb labels with words customers use while searching for products, events, adventures, or expert advice
@@ -230,7 +231,7 @@ Breadcrumbs provide context and a sense of place. This is especially important o
   - If the user browsed to the same article through Camping, show the breadcrumb that includes Camping
   - If the user landed on the article from a Google search, show either category as a breadcrumb
 
-## Behavior
+### Behavior
 
 - Emphasize breadcrumb hover states with an underline
 
@@ -240,7 +241,7 @@ Breadcrumbs provide context and a sense of place. This is especially important o
 <do-dont :examples="$page.frontmatter.path" />
 
 
-### Truncation
+#### Truncation
 
 Indicate hidden links using an ellipsis.
 
@@ -251,20 +252,20 @@ Truncate breadcrumbs left to right to show the final two links in the trail, so 
 <do-dont :examples="$page.frontmatter.truncation" />
 
 
-### Avoid Customization
+#### Avoid Customization
 
 <do-dont :examples="$page.frontmatter.path_symbol" />
 
 
 <do-dont :examples="$page.frontmatter.link" />
 
-## Resources
+### Resources
 
 - [REI Navigation Standards: Breadcrumbs](https://confluence.rei.com/display/NAV/Breadcrumb+Guidance)
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>## Props
@@ -274,16 +275,16 @@ Truncate breadcrumbs left to right to show the final two links in the trail, so 
 **Note:** Truncation only occurs if the ```items``` collection contains more than 2 items and the value is set to ```truncationEnabled=true```.
 
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrBreadcrumb"/>
 
-## Usage
+### Usage
 
 The ```items``` property requires an array of objects, in the format shown above. Notable values include:
 

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -187,9 +187,9 @@
 
 <cdr-doc-table-of-contents-shell tab-name="Overview">
 
-# Overview
+## Overview
 
-## Primary
+### Primary
 
 Use primary buttons for actions to complete a task or to move forward in a process such as &quot;Add to cart.&quot; There is only one primary action per major page section.
 
@@ -204,7 +204,7 @@ Use primary buttons for actions to complete a task or to move forward in a proce
 
 
 
-## Secondary
+### Secondary
 
 Use secondary buttons for all actions that do not move the user to the next step or require additional user actions such as &quot;Add to wish list&quot; or &quot;Find a campout near you.&quot;
 
@@ -217,7 +217,7 @@ Use secondary buttons for all actions that do not move the user to the next step
 
 </cdr-doc-example-code-pair>
 
-## Alternative Styles
+### Alternative Styles
 
 Use `sale` or `dark` for alternative button styling.
 
@@ -232,7 +232,7 @@ Use `sale` or `dark` for alternative button styling.
 
 </cdr-doc-example-code-pair>
 
-## Link Style
+### Link Style
 
 Use `link` modifier to render a button that is styled like a CdrLink. This can be used to create links with the padding and sizing options of a button. Can be used with the `tag` property set to the default `"button"` or `"a"`. For rendering a link inline with text, use [CdrLink](../links). To render a button that behaves like a link, use a [CdrButton with link tag](#button-with-link-tag).
 
@@ -246,7 +246,7 @@ Use `link` modifier to render a button that is styled like a CdrLink. This can b
 
 </cdr-doc-example-code-pair>
 
-## Text and Icon
+### Text and Icon
 
 Pair an icon with text to improve recognition about an object or action.
 
@@ -280,7 +280,7 @@ Pair an icon with text to improve recognition about an object or action.
 
 </cdr-doc-example-code-pair>
 
-## Icon Only
+### Icon Only
 
 Use icons to visually communicate an object or action in a limited space. Include alternative text to describe what the button does.
 
@@ -301,7 +301,7 @@ Use icons to visually communicate an object or action in a limited space. Includ
 
 </cdr-doc-example-code-pair>
 
-## Icon Only With Background
+### Icon Only With Background
 
 Use `with-background` property in conjunction with the `icon-only` property to make icon buttons more identifiable. Include alternative text to describe what the button does.
 
@@ -323,7 +323,7 @@ Use `with-background` property in conjunction with the `icon-only` property to m
 
 </cdr-doc-example-code-pair>
 
-## Stateful Button
+### Stateful Button
 
 For buttons that trigger asynchronous actions, use the `click` event and dynamic properties in order to change the label or state of a button.
 
@@ -338,7 +338,7 @@ For buttons that trigger asynchronous actions, use the `click` event and dynamic
 </cdr-doc-example-code-pair>
 
 
-## Full Width
+### Full Width
 
 Displays at full width of its container.
 
@@ -356,7 +356,7 @@ Displays at full width of its container.
 </cdr-doc-example-code-pair>
 
 
-## Button With Link Tag
+### Button With Link Tag
 
 For a CdrButton that looks like a button but behaves like a link, set `tag="a"` and pass an `href`.
 
@@ -373,7 +373,7 @@ For a CdrButton that looks like a button but behaves like a link, set `tag="a"` 
 
 </cdr-doc-example-code-pair>
 
-## Sizing
+### Sizing
 
 Change the button size based on where the button is used. The default size is medium.
 
@@ -421,9 +421,9 @@ This component has no specific WCAG compliance attributes built into the control
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Triggering an action  
 - Enabling a “final” action  
@@ -432,11 +432,11 @@ This component has no specific WCAG compliance attributes built into the control
 - Confirming the completion of a flow or cancelling out of it
 - Use `tag="a"` and `href` when navigating to another page on the site
 
-## Don't Use When
+### Don't Use When
 
 - Taking users to a different part within the same page. Instead, use [Links](../links/)
 
-## The Basics
+### The Basics
 
 Three button sizes are available: Small, Medium, and Large. Medium is the default size.
 <br />
@@ -463,7 +463,7 @@ When arranging buttons horizontally:
 
 <br />
 
-### Do / Don't
+#### Do / Don't
 
 When grouping buttons, match button sizes either horizontally or vertically.
 
@@ -476,7 +476,7 @@ When grouping buttons, match button sizes either horizontally or vertically.
 <br />
 
 
-## Content
+### Content
 
   - Clearly and concisely label with 1–3 words and fewer than 20 characters, including spaces
   - Start with a verb, if possible. Labels must be action-oriented and set expectations for what the user will see next
@@ -491,7 +491,7 @@ To construct consistent and universal Calls to Action across the site:
 - If leading to a Product Detail page, UI text for Call to Action should be **Shop product name**
 - If leading to a Collection or search result, UI text for Call to Action should be **Shop all Brand/Category/Activity Name**
 
-### Do / Don't
+#### Do / Don't
 
   <do-dont :examples="$page.frontmatter.label" />
 
@@ -499,9 +499,9 @@ To construct consistent and universal Calls to Action across the site:
 
   <do-dont :examples="$page.frontmatter.noun" />
 
-## Behavior
+### Behavior
 
-### Choosing a Button or a Link
+#### Choosing a Button or a Link
 
 When making decisions about whether to use a link or a button, consider the following:
 
@@ -524,34 +524,34 @@ Apply the following use cases when deciding when to use links as anchors or butt
 | Supporting internal page jumps                                                                      | Can be disabled with disabled attribute                                              |
 
 
-## Resources
+### Resources
 
   - WebAIM: [Keyboard Accessibility](https://webaim.org/techniques/keyboard/)
   - WebAIM [WCAG 2.0 Checklist](https://webaim.org/standards/wcag/checklist)
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML button element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) accepts.
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrButton"/>
 

--- a/docs/components/buttons/README.md
+++ b/docs/components/buttons/README.md
@@ -389,7 +389,7 @@ Change the button size based on where the button is used. The default size is me
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:
 
@@ -499,7 +499,6 @@ To construct consistent and universal Calls to Action across the site:
 
   <do-dont :examples="$page.frontmatter.noun" />
 
-### Behavior
 
 #### Choosing a Button or a Link
 

--- a/docs/components/caption/README.md
+++ b/docs/components/caption/README.md
@@ -177,7 +177,7 @@ The captions component is text-only; however, it is meant to be displayed in the
 </cdr-doc-example-code-pair>
 
 
-## Accessibility
+### Accessibility
 
 To ensure that usage of this component complies with the accessibility guidelines, do the following:
 

--- a/docs/components/caption/README.md
+++ b/docs/components/caption/README.md
@@ -112,9 +112,9 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
-## Default (Medium)
+### Default (Medium)
 
 Caption aligns to the left alongside the body copy with inset padding. Default caption includes summary and credit.
 
@@ -128,7 +128,7 @@ Caption aligns to the left alongside the body copy with inset padding. Default c
 
 </cdr-doc-example-code-pair>
 
-## Summary
+### Summary
 
 Summary has same CSS styles as the default; however, only the summary element is displayed.
 
@@ -142,7 +142,7 @@ Summary has same CSS styles as the default; however, only the summary element is
 </cdr-doc-example-code-pair>
 
 
-## Credit
+### Credit
 
 Credit has same CSS styles as the default; however, only the credit element is displayed.
 
@@ -156,7 +156,7 @@ Credit has same CSS styles as the default; however, only the credit element is d
 </cdr-doc-example-code-pair>
 
 
-## Caption with Image
+### Caption with Image
 
 The captions component is text-only; however, it is meant to be displayed in the context of a media object.
 
@@ -192,18 +192,18 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Providing further context and attribution to any figure or media asset such as an image, video, or chart
 
-## Don’t Use When
+### Don’t Use When
 
 - Displaying body copy. Instead, use [Text](../text/#body/)
 - Breaking up the text styles in a layout for aesthetic purposes
 
-## Content
+### Content
 
 The Caption component has two separate fields: Summary and Credit. While they often appear together, one is not dependent on the other. Both are, however, dependent on media content (image, video, etc).
 
@@ -215,7 +215,7 @@ There are two text fields available within a caption:
       - Helps users gauge the strength and validity of the material the author has used
       - Begin credit text with “Video Credit” or “Image Credit”
 
-## Anatomy
+### Anatomy
 
 - Captions align to the left border based on the paragraph container and not centered under the media object
 - Max width is 498 pixels, even if the media (image, video, or chart) extends beyond the paragraph max width
@@ -255,8 +255,6 @@ For copyrighted media (photos or video):
   - NPR Training, Storytelling tips and best practices: [These are NPR's photo caption guidelines](http://training.npr.org/visual/these-are-nprs-photo-caption-guidelines)
 
 
-## Behavior
-
 ### Do / Don’t
 
 Keep summary content short to avoid excess text-wrapping.
@@ -285,16 +283,16 @@ Caption stays left aligned with body copy regardless of the width of the media.
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Usage
+### Usage
 
 The **CdrCaption** component is developed to work within a composition with other components; however, composition-type components have not been developed yet.
 

--- a/docs/components/card/README.md
+++ b/docs/components/card/README.md
@@ -196,20 +196,20 @@ Many WCAG requirements are contextual to their implementation. To ensure that us
 
 <do-dont :examples="$page.frontmatter.grouping" />
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrCard"/>
 

--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -470,31 +470,31 @@ Checkboxes work independently from each other:
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML checkbox element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox) accepts.
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrLabelWrapper"/>
 
-## Usage
+### Usage
 
 The **CdrCheckbox** component requires  `v-model`  to track  `:checked`  values.
 
@@ -570,7 +570,7 @@ Set the `indeterminate` prop to `true` to generate an indeterminate checkbox, wh
 </template>
 ```
 
-### Modifiers
+#### Modifiers
 
 Following variants are available to the `cdr-checkbox` modifier attribute:
 | Value | Description            |

--- a/docs/components/checkboxes/README.md
+++ b/docs/components/checkboxes/README.md
@@ -464,7 +464,7 @@ Checkboxes work independently from each other:
 
 <do-dont :examples="$page.frontmatter.simplify" />
 
-## Resources
+### Resources
 
  - WebAIM: [Semantic Structure: Using Lists Correctly](https://webaim.org/techniques/semanticstructure/)
 

--- a/docs/components/chips/README.md
+++ b/docs/components/chips/README.md
@@ -359,7 +359,7 @@ For multiple select chip groups, apply `role='checkbox'` to each chip, use `aria
 
 
 
-## Accessibility
+### Accessibility
 Many WCAG requirements are contextual to their implementation. To ensure that usage of this component complies with accessibility guidelines:
 
 - For a group of chips related to a single selection, use `role="radio"`, `aria-checked`, and `tabindex` on each chip and wrap the group in a CdrChipGroup component. The selected chip should have `aria-checked="true"` and `tabindex="0"` set, while the rest of the chips should have `aria-checked="false"` and `tabindex="-1"`.
@@ -476,7 +476,7 @@ When making decisions about whether to use a button, links or chips, consider th
 | Opening a modal window                           | Changing the URL                                          | Offering a choice or representing a filter |
 | Triggering a popup menu                          | Causing a browser redraw or refresh                       | Immediately changing a setting on the page |
 
-## Resources
+### Resources
   - WebAIM: [Keyboard Accessibility](https://webaim.org/techniques/keyboard/)
   - WebAIM [WCAG 2.0 Checklist](https://webaim.org/standards/wcag/checklist)
   - W3C: [WCAG 3.0 Guidelines](https://www.w3.org/TR/wcag-3.0/)

--- a/docs/components/chips/README.md
+++ b/docs/components/chips/README.md
@@ -230,10 +230,10 @@
 
 <cdr-doc-table-of-contents-shell>
 
-# Overview
+## Overview
 Chips are compact elements that represent a selection, attribute, or dynamic action.
 
-## Default
+### Default
 
 Use chips to directly specify, dynamically categorize or immediately perform a discrete action.
 
@@ -248,7 +248,7 @@ Use chips to directly specify, dynamically categorize or immediately perform a d
 ```
 </cdr-doc-example-code-pair>
 
-## Icon Slots
+### Icon Slots
 
 Use `icon-left` or `icon-right` slots to pass icons into a chip. Place the X remove icon in the icon-right slot only. Place other icons in the icon-left slot. Use only one icon per chip.
 
@@ -263,7 +263,7 @@ Use `icon-left` or `icon-right` slots to pass icons into a chip. Place the X rem
 ```
 </cdr-doc-example-code-pair>
 
-## Stateful Chips
+### Stateful Chips
 
 Use stateful chips to update settings immediately or trigger an immediate action while staying on the same page.
 
@@ -299,7 +299,7 @@ For chips that toggle a single selection on and off, use the click event and d
 </cdr-doc-example-code-pair>
 
 
-## Filter Chips
+### Filter Chips
 
 Filter chips add a visual representation of user selected filters. Filter chips that represent user selections that can be dynamically removed should include an X icon in the right icon slot and be linked to the ID of the input it controls using `aria-controls`. The `aria-pressed` property should be set to true to designate that this selection is active. Filter chips that are linked to a checkbox should appear selected and be included in the same form group as the checkboxes.
 
@@ -315,11 +315,11 @@ Filter chips add a visual representation of user selected filters. Filter chips 
 </cdr-doc-example-code-pair>
 
 
-## Selection Chips
+### Selection Chips
 
 Use selection chips to allow users to make a single select choice or a multiple select choice. Single select chip groups are a more prominent alternative to radio buttons while multiple select chip groups are a more prominent alternative to checkboxes.
 
-### Single Select
+#### Single Select
 
 For single select chip groups, apply `role='radio'` to each chip, use `aria-checked="true"` and `tabindex="0"` to designate the selected chip, and apply `aria-checked="false"` and `tabindex="-1"` to the other chips. The chip elements should be grouped directly inside a CdrChipGroup element to ensure keyboard navigation is properly managed. The CdrChipGroup element requires a label property or slot be passed in which describes the chip group. This label is visually hidden by default.
 
@@ -338,7 +338,7 @@ For single select chip groups, apply `role='radio'` to each chip, use `aria-chec
 ```
 </cdr-doc-example-code-pair>
 
-### Multiple Select
+#### Multiple Select
 
 For multiple select chip groups, apply `role='checkbox'` to each chip, use `aria-checked="true"` to designate the selected chip, and apply `aria-checked="false"` to the other chips. The chip elements should be grouped directly inside a CdrChipGroup element to ensure keyboard navigation is properly managed. The CdrChipGroup element requires a label property or slot be passed in which describes the chip group. This label is visually hidden by default.
 
@@ -371,11 +371,11 @@ CdrChip and CdrChipGroup implement the following accessibility requirements:
 - CdrChip uses a button tag
 - CdrChipGroup implements keyboard navigation for a group of CdrChips
 
-# Guidelines
+## Guidelines
 
 Chips allow users to make selections, filter content, or trigger actions. While buttons are expected to appear consistently and with familiar calls to action, chips should appear dynamically.
 
-## Use when
+### Use when
 
 - Dynamically categorizing content based on descriptive words
 - Representing a checkbox group with more emphasis
@@ -385,14 +385,14 @@ Chips allow users to make selections, filter content, or trigger actions. While 
 - Allowing the user to trigger an immediate action while staying on the same page
 - Allowing users to update or configure settings immediately
 
-## Don’t use when
+### Don’t use when
 
 - Navigating a user. Instead, use [Buttons](../buttons/) or [Links](../links/)
 - Displaying non-interactive elements
 - Displaying more than two rows of chips. Instead use horizontal scrolling or [Selects](../selects/)
 - Representing page tags
 
-## The Basics
+### The Basics
 
 One chip container style is available: pill.
 
@@ -409,7 +409,7 @@ When stacking chips vertically:
 <cdr-img class="cdr-doc-article-img" :src="$withBase(`/chips/basics_vertical.png`)"/>
 
 
-## Content
+### Content
 
 When using chips in a group:
 - Use a logical order, whether it’s alphabetical, numerical, or time-based
@@ -424,7 +424,7 @@ Chip text should:
 - No terminal punctuation
 
 
-## Do / Don't
+### Do / Don't
 
 <do-dont :examples="$page.frontmatter.case" />
 <do-dont :examples="$page.frontmatter.phrasing" />
@@ -452,7 +452,7 @@ When representing radio button or checkbox groups, include more than 2 chips in 
 
 <do-dont :examples="$page.frontmatter.DATAKEY" /> -->
 
-## Behavior
+### Behavior
 
 Stateful chips used to dynamically perform a discrete action:
 - Can show confirmation feedback.
@@ -481,28 +481,30 @@ When making decisions about whether to use a button, links or chips, consider th
   - WebAIM [WCAG 2.0 Checklist](https://webaim.org/standards/wcag/checklist)
   - W3C: [WCAG 3.0 Guidelines](https://www.w3.org/TR/wcag-3.0/)
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## CdrChip
-### Props
+### CdrChip
+
+#### Props
 
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-### Slots
+#### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## CdrChipGroup
-### Props
+### CdrChipGroup
+
+#### Props
 
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[1].api.props" />
 
-### Slots
+#### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[1].api.slots" />
 

--- a/docs/components/container/README.md
+++ b/docs/components/container/README.md
@@ -104,16 +104,16 @@ The default `static` CdrContainer has a flexible content width up to a max width
 </cdr-container>
 ```
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 

--- a/docs/components/form-group/README.md
+++ b/docs/components/form-group/README.md
@@ -256,20 +256,20 @@ In CdrFormGroup, all of the related fields go inside the `fieldset` element, and
 - Creating a single form field that asks for a single piece of information
 
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrFormGroup"/>
 

--- a/docs/components/grid/README.md
+++ b/docs/components/grid/README.md
@@ -738,20 +738,20 @@ To build an effective responsive grid:
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Usage
+### Usage
 
 **CdrGrid** functions as a grid container, and it's immediate children are grid items.
 

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -126,9 +126,9 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
-## Inline Icon Components
+### Inline Icon Components
 
 The inline icon components are the recommended method for using Cedar icons in a Vue application. Cedar exports a component version of every SVG Icon in the [Cedar Icon Library](../../icons/library). These components are named using PascalCase, for example `account-profile` becomes `IconAccountProfile` or `camping` becomes `IconCamping`.
 
@@ -141,7 +141,7 @@ The inline icon components are the recommended method for using Cedar icons in a
 
 </cdr-doc-example-code-pair>
 
-## SVG Sprite
+### SVG Sprite
 
 A collection of SVG icon files composed into a single file. This method provides a single server download request and caches icons for display. This is the most efficient way of displaying large numbers of icons, but has an added maintenance cost in that every icon used in the application must be manually added to it's sprite sheet. We recommend using the [inline icon components](#inline-icon-components), and optimizing to use a sprite only if it would provide a measurable performance benefit.
 
@@ -157,7 +157,7 @@ Visit the [Cedar Icon Sprite Creator](https://rei.github.io/cedar-icons/#/sprite
 </cdr-doc-example-code-pair>
 
 
-## Non-Cedar SVG
+### Non-Cedar SVG
 
 Create a new SVG icon using any valid SVG markup. The wrapping SVG element can be stripped (below) or maintained. Ensure that ID is not a used attribute in your icon to avoid introducing non-unique ID's on a page that may use this icon several times. Note that if it is not stripped, then `viewBox`, `role`, and `xmlns` attributes will not be preserved. Whereas, all other attributes will be preserved. This method creates an outer SVG wrapper for accessibility and styles. This is not recommended if using a large number of icons. See the [icon overview](../../icons/overview/) page for more details on building SVG for use with Cedar.
 
@@ -264,31 +264,32 @@ Recommendations for writing screen reader text:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 - Communicating simple actions and concepts that are easily understood, such as printing a receipt or sending an email
 - Making navigation easier for common actions, such as return to home page or search
 - Representing an action, object, or concept at a high level of abstraction, such as using the snowflake icon to represent snow sports
 - Notifying users about status, such as the number of items in a shopping cart or a warning message
 - Conserving space for concepts that are difficult to depict, such as the progress icon or the 3-line “hamburger” menu
 
-## The Basics
-### Sizes
+### The Basics
+
+#### Sizes
 Icons are available in three sizes: small (16px), medium (24px), and large (32px).  Default size is medium (24px); however, designers can choose a different size.
 
 <cdr-img class="cdr-doc-article-img" :src="$withBase(`/icon/Spec__Icon__Sizes.png`)" alt="Cedar icon sizes." />
 
 
 
-### Color
+#### Color
 Ensure that icons use the ratio of 4.5:1 contrast between icon color and background color. Follow recommendations in the [Color Foundation](../../foundation/color/) article for pairing color tokens.
 
 <cdr-img class="cdr-doc-article-img" :src="$withBase(`/icon/Spec__Icon__Colors.png`)" alt="Cedar icon color options." />
 
 
 
-### Clearance
+#### Clearance
 Adequate space around the icon allows for legibility and touch. A minimum touch target area of 40px is recommended for standalone iconography.
 
 When the mouse and keyboard are the primary input methods or when icons are paired inline with text, measurements may be condensed to accommodate denser layouts. Icon size should align to the line-height of the paired text element.
@@ -297,11 +298,11 @@ When the mouse and keyboard are the primary input methods or when icons are pair
 
 
 
-## Icon Library
+### Icon Library
 
 For a list of all available icons and their names, visit the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/).
 
-## Behavior
+### Behavior
 
 When using icons with links or buttons, ensure that the icon communicates intended meaning.
 
@@ -315,26 +316,26 @@ Ensure that icons use contrast ratio of 4.5:1 between icon color and background 
 
 <do-dont :examples="$page.frontmatter.color" class="stack-2"/>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Usage
+### Usage
 
 For a list of all available icons and their names, visit the [Cedar Icon Library](https://rei.github.io/cedar-icons/#/).
 
 There are 2 different options to display SVG icons on your page using the **CdrIcon** package.
 
-### 1. SVG Sprite
+#### 1. SVG Sprite
 
 Requires:
 - Icon sprite inline on page
@@ -388,7 +389,7 @@ components: {
 </script>
 ```
 
-### 2. Non-Cedar SVG
+#### 2. Non-Cedar SVG
 
 The **CdrIcon** package is simply an SVG with default attributes set for accessibility and styling.
 

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -191,7 +191,7 @@ Create a new SVG icon using any valid SVG markup. The wrapping SVG element can b
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 CdrIcon by default adds `aria-hidden="true"` to the root SVG element. If your usage of CdrIcon is purely decorative, or if the icon is already explained by the text surrounding it, then there are no other accessibility steps needed.
 

--- a/docs/components/icon/README.md
+++ b/docs/components/icon/README.md
@@ -126,6 +126,7 @@
 
 
 <cdr-doc-table-of-contents-shell>
+
 ## Overview
 
 ### Inline Icon Components

--- a/docs/components/image/README.md
+++ b/docs/components/image/README.md
@@ -84,10 +84,10 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
 
-## Default (Medium)
+### Default (Medium)
 
 Use for images with no responsive qualities.
 
@@ -104,7 +104,7 @@ Use for images with no responsive qualities.
 ```
 </cdr-doc-example-code-pair>
 
-## Managing Images
+### Managing Images
 
 Apply rules to an image using ratio and crop properties. The below example is cropped using top alignment with the aspect ratio set as 9:16.
 
@@ -122,7 +122,7 @@ Apply rules to an image using ratio and crop properties. The below example is cr
 ```
 </cdr-doc-example-code-pair>
 
-## Displaying Images as Backgrounds
+### Displaying Images as Backgrounds
 
 Use the cover property to resize the background image to fill the entire container.
 
@@ -142,7 +142,7 @@ Use the cover property to resize the background image to fill the entire contain
 </cdr-doc-example-code-pair>
 
 
-## Ratio Auto
+### Ratio Auto
 
 To use cover or crop properties without a defined aspect ratio, set `ratio="auto"` and give the image an explicit height and/or width. This can be done in several ways:
 - Apply `height` or `min-height` to the CdrImg element directly
@@ -192,11 +192,11 @@ To use cover or crop properties without a defined aspect ratio, set `ratio="auto
 
 
 
-## Shaping Images
+### Shaping Images
 
 Apply a radius to an image.
 
-### Rounded
+#### Rounded
 The below example is cropped using center alignment with the aspect ratio set as square and the radius set as rounded.
 
 
@@ -214,7 +214,7 @@ The below example is cropped using center alignment with the aspect ratio set as
 
 </cdr-doc-example-code-pair>
 
-### Circle
+#### Circle
 The below example is cropped using center alignment with the aspect ratio set as square and the radius set as circle.
 
 
@@ -232,7 +232,7 @@ The below example is cropped using center alignment with the aspect ratio set as
 
 </cdr-doc-example-code-pair>
 
-### Error Event Handler
+#### Error Event Handler
 
 CdrImg will bind any event handlers to the `img` element that it wraps. This is intended to support attaching an error handler function in case an image does not load, but can be used for any HTML/JS event. Note that because images are usually not "interactive" elements you should not bind click handlers to them.
 
@@ -247,7 +247,7 @@ CdrImg will bind any event handlers to the `img` element that it wraps. This is 
 
 </cdr-doc-code-snippet>
 
-## Lazy Loading
+### Lazy Loading
 
 The CdrImg component accepts any valid HTML `img` attribute. CdrImg works with [native lazy loading](https://css-tricks.com/native-lazy-loading/) by setting the `loading` attribute.
 
@@ -288,9 +288,9 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Illustrating a product feature
 - Allowing comparisons between similar items
@@ -299,11 +299,11 @@ This component has compliance with WCAG guidelines by:
 - Communicating the REI brand message
 - Explaining a complex procedure or how to perform an action
 
-## The Basics
+### The Basics
 
 REI image requirements are described on the [Launch and DefaultShop Image Sizes](https://confluence.rei.com/display/CMA/Launch-and-DefaultShop-Image-Sizes) page.
 
-### Aspect Ratio
+#### Aspect Ratio
 
 Use conventional aspect ratios:
 
@@ -311,27 +311,27 @@ Use conventional aspect ratios:
 - Portrait: 1:2, 2:3, 3:4, 9:16
 - Landscape: 2:1, 3:2, 4:3, 16:9
 
-### Quality
+#### Quality
 
 - Always maintain high image quality
 - Choose the right file format when saving your images to ensure proper image quality and file size:
   - For photos, use JPEG. Optimize JPEG files to find a balance between size and quality
   - For bitmap/raster artwork, use PNG with 8-bit color palette
 
-### Sizing
+#### Sizing
 
 - Avoid small file sizes that pixelate the image
 - Avoid unnecessarily large file sizes. Export images at the lowest file size possible without compromising quality
 - Optimize high resolution images using [TinyPNG](https://tinypng.com/)
 - Must display images at a proper pixel size compared to natural size
 
-### Color and Contrast
+#### Color and Contrast
 
 - Test images for high contrast displays
 - Ensure that no meaning is lost when colors are removed
 - Include text only with sufficient contrast
 
-### Cropping Images
+#### Cropping Images
 
 - Specify the ratio of all cropped images
 - Enable background image to use the entire container:
@@ -359,14 +359,14 @@ Images are cropped on y-axis with y-center value and on x-axis with left, x-cent
 Images are cropped on y-axis with bottom value and on x-axis with left, x-center, and right values
 
 
-## Content
+### Content
 
-### File Names
+#### File Names
 - Image file name should include primary keyword or what the page is targeting
 - Showcase keyword targeting through file name and alt text
 - For more information, view SEO How-to article [Image Implementation](https://confluence.rei.com/display/SI/Image+Implementation)
 
-### Overlaid Text
+#### Overlaid Text
 
 - Only display heading text on non-solid backgrounds:
   - Text should be at least 18px
@@ -376,14 +376,14 @@ Images are cropped on y-axis with bottom value and on x-axis with left, x-center
 - Always include a backup background color so that when the background image is disabled, text is still legible and passes contrast requirements
 - For help in determining whether your text and image combination conforms to the required contrast ratio, use the [Color Contrast Analyzer](https://chrome.google.com/webstore/detail/color-contrast-analyzer/dagdlcijhfbmgkjokkjicnnfimlebcll) Chrome plugin
 
-### Decorative Images
+#### Decorative Images
 
 - Avoid using decorative images; instead present the image as a background image using CSS
 - If using the HTML `<img>` element, add:
   - An empty `alt` attribute
   - Attribute ` role="presentation" `
 
-### Alternative Text
+#### Alternative Text
 
 - Use [this decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/) to determine how to use the `alt` attribute
 - Be succinct. Ideally, one sentence or less
@@ -398,7 +398,7 @@ Images are cropped on y-axis with bottom value and on x-axis with left, x-center
   - Must provide an overall context for the set of links using `alt` attribute
   - Each individual clickable area should have an `alt` attribute that describes the purpose or destination of the link
 
-## Responsiveness
+### Responsiveness
 - Ability to control image display at small, medium, and large breakpoints
 - Lazy loading of images is provided
 - The `srcet` and `sizes` attributes can be used to control which image loads at which screeen size
@@ -410,12 +410,12 @@ Images are cropped on y-axis with bottom value and on x-axis with left, x-center
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML img element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) accepts.
 

--- a/docs/components/image/README.md
+++ b/docs/components/image/README.md
@@ -84,6 +84,7 @@
 
 
 <cdr-doc-table-of-contents-shell>
+
 ## Overview
 
 
@@ -264,7 +265,7 @@ The CdrImg component accepts any valid HTML `img` attribute. CdrImg works with [
 ```
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 To ensure that usage of this component complies with accessibility guidelines, provide descriptive text for `alt` attribute for:
 - Informative images:
@@ -403,7 +404,7 @@ Images are cropped on y-axis with bottom value and on x-axis with left, x-center
 - Lazy loading of images is provided
 - The `srcet` and `sizes` attributes can be used to control which image loads at which screeen size
 
-## Resources
+### Resources
 
 - Chrome plugin, [Color Contrast Analyzer](https://chrome.google.com/webstore/detail/color-contrast-analyzer/dagdlcijhfbmgkjokkjicnnfimlebcll)
 - Image compression service, [TinyPNG](https://tinypng.com/)

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -236,9 +236,9 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
-## Default (Medium)
+### Default (Medium)
 Basic input field with label.
 
 
@@ -261,7 +261,7 @@ Basic input field with label.
 
 </cdr-doc-example-code-pair>
 
-## Required
+### Required
 
 Basic input field with label and required tag.
 
@@ -279,7 +279,7 @@ Basic input field with label and required tag.
 
 </cdr-doc-example-code-pair>
 
-## Optional
+### Optional
 
 Basic input field with label and optional tag.
 
@@ -297,7 +297,7 @@ Basic input field with label and optional tag.
 
 </cdr-doc-example-code-pair>
 
-## Sizing
+### Sizing
 
 Change size for the input field. Default size is medium.
 
@@ -321,7 +321,7 @@ Change size for the input field. Default size is medium.
 
 </cdr-doc-example-code-pair>
 
-## Bare
+### Bare
 
 Input field with no label.
 
@@ -339,7 +339,7 @@ Input field with no label.
 
 </cdr-doc-example-code-pair>
 
-## Validation
+### Validation
 
 Input field with validation that runs on `blur`. Error state is controlled with the `error` prop. Setting the `error` prop to a string will render that message with default error styling. The `error` slot can be used to fully customize the error message.
 
@@ -368,7 +368,7 @@ Error messaging will override helper text rendered in the bottom position.
 
 </cdr-doc-example-code-pair>
 
-## Multi-Line Input
+### Multi-Line Input
 
 Multiple line input field with expander control in lower right. Note that the pre-icon, post-icon, and info-action slots will not work properly in multi-line inputs.
 
@@ -385,7 +385,7 @@ Multiple line input field with expander control in lower right. Note that the pr
 
 </cdr-doc-example-code-pair>
 
-## Numeric Input
+### Numeric Input
 
 Input field designed to accept numerical input. Launches the numerical keyboard on mobile devices. Does not use the `type="number"` attribute as that is intended for values that are strictly "numbers" such as quantities and not values that contain numerical characters such as credit cards, security codes, month/year values, etc. Can be used in conjunction with [input masking](#input-masking) to handle formatting values like credit cards, or an `input` listener can be used to format or restrict input.
 
@@ -404,7 +404,7 @@ Input field designed to accept numerical input. Launches the numerical keyboard 
 
 </cdr-doc-example-code-pair>
 
-## Number/Quantity Input
+### Number/Quantity Input
 
 Use the `type="number"` attribute only for input fields that reference a numerical value, for example a quantity of something. For input fields that are composed of numerical characters but are not strictly a number value, for example a credit card number or a month/year value, use a [numeric input](./#numeric-input) instead. An input field with `type="number"` set will only accept pure number values as input and rejects all other content, which can cause issues with a numeric identifier that has leading zeroes and may behave differently across browsers and devices.
 
@@ -430,7 +430,7 @@ Use the `type="number"` attribute only for input fields that reference a numeric
 
 </cdr-doc-example-code-pair>
 
-## Input with Link Text
+### Input with Link Text
 
 Input field with link text on right. The link should describe it's relationship to the input field either through it's text content or an aria-label.
 
@@ -451,7 +451,7 @@ Input field with link text on right. The link should describe it's relationship 
 
 </cdr-doc-example-code-pair>
 
-## Input with Info Action
+### Input with Info Action
 
 Input field with icon wrapped in an actionable element outside the input field on right. The actionable element should have an aria-label that explains it's relationship to the input field and what happens when you click on it.
 
@@ -478,7 +478,7 @@ Input field with icon wrapped in an actionable element outside the input field o
 
 </cdr-doc-example-code-pair>
 
-## Input with Helper Text
+### Input with Helper Text
 
 Input field with helper or hint text below the input field. If the input is in an error state, the error messaging slot will override this text. Helper text should be used instead of the HTML `placeholder` attribute to provide additional information or context about the input.  Helper text is automatically linked to the input field through the `aria-describedby` attribute.
 
@@ -538,7 +538,7 @@ Input field with icon inserted into the input field on left. Icon is decorative 
 
 </cdr-doc-example-code-pair>
 
-## Input with Icon Inserted Right
+### Input with Icon Inserted Right
 
 Input field with icon inserted into the input field on right. Icon is decorative and not intended for any action.
 
@@ -563,7 +563,7 @@ Input field with icon inserted into the input field on right. Icon is decorative
 </cdr-doc-example-code-pair>
 
 
-## Input with Actions
+### Input with Actions
 
 Input field with icon buttons inserted to the right. Up to 2 buttons can be passed into the `post-icon` slot. Each button should have the `cdr-input__button` utility class applied to it. Each button should indicate it's function and relationship to the input field through either an `aria-label` or a tooltip.
 
@@ -643,30 +643,30 @@ Any additional actionable elements related to the input field, which may be exte
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Entering data with a wide variety of responses
 - Searching for content
 
-## Don't Use When
+### Don't Use When
 
 - Selecting from a specific set of options. Instead, use [Selects](../selects/)
 
-## The Basics
+### The Basics
 
 - **Identifiable** - Input fields should indicate that users can enter information
 - **Findable** - It should be easy to find an input field among other elements
 - **Legible** - Input fields indicate their state such as enabled, focused, or disabled
 
-### Options
+#### Options
 
 - Define width using CSS styles
 - Height options are medium or large.
 - Ability to specify field type for text, email, number, password, search, and URL
 
-### Multi-Line Input Fields
+#### Multi-Line Input Fields
 
 - Use when long free-form text is the desired user input such as a comment on a review or feedback form
 - Overflow text wraps to a new line
@@ -677,33 +677,33 @@ Any additional actionable elements related to the input field, which may be exte
   - Max-height of text area
   - Maximum and minimum number of characters
 
-## Content
+### Content
 
-### Labels
+#### Labels
 
 - Use concise and consistent labels that describes the meaning of the input field
 - Limit labels to 1–3 words and fewer than 20 characters, including spaces
 - Use sentence case. Do not use all caps, title caps, or all lowercase
 - Don’t use colons after labels
 
-### Helper Text
+#### Helper Text
 
 - Use helper text for hints or suggestions
 - If help text is long or complex, use an icon or link above the input box
 - Too much helper help text can make a form look and feel difficult to use
 
-### Icon
+#### Icon
 
 - Use icons to trigger a popover for hints or suggestions
 - Reference Cedar's [icon guidelines](../icon/#guidelines/) for additional information
 
-### Link Text
+#### Link Text
 
 - Use a link when moving or navigating to another page or to a different portion of the same page
 - Use if navigating user to long or complex information
 - Reference the [Links](../links/) component article for more information
 
-### Do / Don't
+#### Do / Don't
 
 <do-dont :examples="$page.frontmatter.length" />
 
@@ -717,9 +717,9 @@ Any additional actionable elements related to the input field, which may be exte
 
 <do-dont :examples="$page.frontmatter.sizes" />
 
-## Behavior
+### Behavior
 
-### Default Input Attrs
+#### Default Input Attrs
 
 CdrInput sets some default attributes to make it easier to construct consistent and accessible forms. These default attributes can be overridden by passing the same attribute to the CdrInput component.
 
@@ -745,7 +745,7 @@ Note that the `maxlength` attribute does not work in conjunction with numeric in
 ```
 
 
-### Input Masking
+#### Input Masking
 
 User input should be automatically formatted to make forms easier to comprehend and use, for example by adding parentheses and a dash to a phone number or inserting a space between every four digits of a credit card number.
 
@@ -788,37 +788,37 @@ export default {
 
 ```
 
-### Inputs with Icons
+#### Inputs with Icons
 
 - Icons inserted into input fields are decorative, not intended for any action
 
-### Required Fields
+#### Required Fields
 
 - The default status of an input field is “optional”. Setting the `optional` prop on the input will render a text label indicating it is optional
 - If the status is set to “required”, an asterisk will appear next to the input label with an aria-label indicating that the input is required and the input field will be marked `aria-required`
 
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" title="An outline caricature of a cat" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML input element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) accepts.
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props"/>
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" :slots-getting-started-link="false" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrInput">Note that the <a href="../component-variables/#CdrLabelStandalone">cdr-label-standalone mixins</a> should be used for assembling the label element. </cdr-doc-comp-vars>
 

--- a/docs/components/input/README.md
+++ b/docs/components/input/README.md
@@ -498,7 +498,7 @@ Input field with helper or hint text below the input field. If the input is in a
 
 </cdr-doc-example-code-pair>
 
-## Input with Helper Text Above
+### Input with Helper Text Above
 
 Input field with helper or hint text rendered above the input field. Helper text should be used instead of the HTML `placeholder` attribute to provide additional information or context about the input. Helper text is automatically linked to the input field through the `aria-describedby` attribute.
 
@@ -518,7 +518,7 @@ Input field with helper or hint text rendered above the input field. Helper text
 
 </cdr-doc-example-code-pair>
 
-## Input with Icon Inserted Left
+### Input with Icon Inserted Left
 
 Input field with icon inserted into the input field on left. Icon is decorative and not intended for any action.
 
@@ -631,7 +631,7 @@ Input field with icon buttons inserted to the right. Up to 2 buttons can be pass
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 This component has compliance with WCAG guidelines by:
 - Requiring a value for the `label` field

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -196,7 +196,7 @@ To render a link that has the spacing and sizing of a button, use [CdrButton wit
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:

--- a/docs/components/links/README.md
+++ b/docs/components/links/README.md
@@ -97,9 +97,9 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
-## Default (Medium)
+### Default (Medium)
 
 Display within body copy for articles, hub cards, footer, or recommendations.
 
@@ -121,7 +121,7 @@ Display within body copy for articles, hub cards, footer, or recommendations.
 
 </cdr-doc-example-code-pair>
 
-## Standalone
+### Standalone
 
 Display independently with a Call to Action. Some examples are for finding a store, or viewing related products.
 
@@ -135,7 +135,7 @@ Display independently with a Call to Action. Some examples are for finding a sto
 
 </cdr-doc-example-code-pair>
 
-## Icon on Left
+### Icon on Left
 
 Display standalone link with icon on left.
 
@@ -152,7 +152,7 @@ Display standalone link with icon on left.
 
 </cdr-doc-example-code-pair>
 
-## Icon on Right
+### Icon on Right
 
 Display standalone link with icon on right.
 
@@ -172,7 +172,7 @@ Display standalone link with icon on right.
 </cdr-doc-example-code-pair>
 
 
-## Inline Link Button
+### Inline Link Button
 
 Use the `tag` prop to render a button that looks like a link. Can be used inline with other text. Should trigger an action rather than navigate to a new page.
 
@@ -233,17 +233,17 @@ This component has compliance with following WebAIM’s accessibility guidelines
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Navigating to another page or a different portion of the same page
 
-## Don't Use When
+### Don't Use When
 
 - Navigating a user from promotional or campaign content. Instead, use [Buttons](../buttons/) styled to match the campaign
 
-## The Basics
+### The Basics
 
 - Link styles are adapted based on context, such as for links included in the [Breadcrumb](../breadcrumb/), Menus, and Navigation
 - There are 2 basic link styles: default and standalone
@@ -252,7 +252,7 @@ This component has compliance with following WebAIM’s accessibility guidelines
 - When using multiple inline links together, be sure that their behaviors are consistent. For instance, don't have one link go to a new page and another one in the group trigger an action
 - Link buttons are often useful for reducing the visual clutter of large groups of actions. For example, when there are many cards in a group using the link button style instead of a true button style
 
-## Content
+### Content
 
 Use link labels that describe the link’s destination when clicked or tapped:
 
@@ -264,7 +264,6 @@ Use link labels that describe the link’s destination when clicked or tapped:
 - Don’t capitalize links. Some screen readers read capitalized text letter-by-letter. Instead, use sentence case
 - Restrict the number of text links on a page. Screen reader will read all the links on a page
 
-## Behavior
 
 ### Choosing a Button or Link
 
@@ -287,42 +286,43 @@ Apply the following use cases when deciding when to use links as anchors or butt
 | Changing the URL                      	| Opening a modal window            	|
 | Causing a browser redraw/refresh      	| Triggering a popup menu           	|
 | Supporting internal page jumps        	| Playing media content             	|
+
 ### Do / Don’t
 
 <do-dont :examples="$page.frontmatter.standalone" />
 
 <do-dont :examples="$page.frontmatter.link" />
 
-## Resources
+### Resources
 
 WebAIM: Links and Hypertext [Introduction to Links and Hypertext](https://webaim.org/techniques/hypertext/)
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) accepts.
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events"/>
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrLink"/>
 
-## Usage
+### Usage
 
 By default, the component renders using an anchor element and requires an `href` attribute to render a valid, accessible link.
 
@@ -340,7 +340,7 @@ Use the `tag` prop to render the link as a `<button>` element that appears as a 
   </cdr-link>
 ```
 
-### Style Modifier
+#### Style Modifier
 
 Following variants are available to the `cdr-link` modifier attribute:
 

--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -91,6 +91,7 @@
 
 
 <cdr-doc-table-of-contents-shell>
+
 ## Overview
 
 ### Bare

--- a/docs/components/lists/README.md
+++ b/docs/components/lists/README.md
@@ -91,9 +91,9 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
-## Bare
+### Bare
 
 Collect items to be displayed in a list when items are not marked with bullets.  This is the default and is also known as unordered and undecorated “bare” list.
 
@@ -114,7 +114,7 @@ Collect items to be displayed in a list when items are not marked with bullets. 
 
 </cdr-doc-example-code-pair>
 
-## Unordered
+### Unordered
 
 Collect related items that don’t need to be in a specific order or sequence. List items are typically marked with bullets.
 
@@ -134,7 +134,7 @@ Collect related items that don’t need to be in a specific order or sequence. L
 
 </cdr-doc-example-code-pair>
 
-## Ordered
+### Ordered
 
 Collect related items with numeric order or sequence. Numbering starts at 1 with the first list item and increases by increments of 1 for each successive ordered list item.
 
@@ -154,7 +154,7 @@ Collect related items with numeric order or sequence. Numbering starts at 1 with
 
 </cdr-doc-example-code-pair>
 
-## Compact
+### Compact
 
 Compact modifier can be added to any `cdr-list` in order to reduce the margin between list items.
 
@@ -174,7 +174,7 @@ Compact modifier can be added to any `cdr-list` in order to reduce the margin be
 
 </cdr-doc-example-code-pair>
 
-## Inline
+### Inline
 
 Display items horizontally with no divider.
 
@@ -190,7 +190,7 @@ Display items horizontally with no divider.
 
 </cdr-doc-example-code-pair>
 
-## Inline - Unordered
+### Inline - Unordered
 
 Display items horizontally, separated by a bullet character.
 
@@ -206,7 +206,7 @@ Display items horizontally, separated by a bullet character.
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 To ensure that usage of this component complies with accessibility guidelines:
 
@@ -235,23 +235,23 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Displaying groups of related items represented by text
 
-## Don't Use When
+### Don't Use When
 
 - Displaying content that is not primarily text
 - Displaying content with two or more well-defined dimensions. Instead, use [Table](../table/)
 
-## The Basics
+### The Basics
 
 - Lists can inherit cdr-text modifiers to make any text a list
 - Follow spacing requirements outlined in the [Typography](../../foundation/typography/) and [Spacing](../../foundation/spacing/) foundation articles.
 
-## Content
+### Content
 
 Break up chunks of content to make the information easier to scan:
 
@@ -280,7 +280,7 @@ Every item in a list must:
 - Use semicolons when linking independent clauses and product details in the list
 - End each sentence in a list item with a period when there are multiple sentences; however, don’t add a period for the last sentence or phrase
 
-### Do / Don’t
+#### Do / Don’t
 
 <do-dont :examples="$page.frontmatter.list1" />
 
@@ -288,32 +288,32 @@ Every item in a list must:
 <do-dont :examples="$page.frontmatter.list2" />
 
 
-## Resources
+### Resources
 
 WebAIM: [Semantic Structure: Using Lists Correctly](https://webaim.org/techniques/semanticstructure/)
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML list element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul) accepts (with exception of `type` attribute for ordered lists, use the `list-style-type` CSS property instead).
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props"/>
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrList"/>
 
-## Usage
+### Usage
 
 Visual style and semantic meaning are managed independently by providing:
 
@@ -337,7 +337,7 @@ The **CdrList** component has decoupled the semantic tags `<ul>` and `<ol>` from
 
 It is possible to render a semantic ordered list `<ol>` as a visually non-styled or bulleted list using the `cdr-list` modifiers. With this decoupling, individual list items can contain a variety of HTML elements, including paragraphs, headings, form elements, and other (nested) lists. Ensure that content is structured and follows design guidelines.
 
-### Tag Variants
+#### Tag Variants
 
 Following are different types of lists:
 
@@ -364,7 +364,7 @@ Following are different types of lists:
 - Bare or unstyled lists:
   - Contains a variety of HTML elements, including paragraphs, headings, form elements, and other (nested) lists
 
-### Modifiers
+#### Modifiers
 
 Note that the tag itself does not determine display, a modifier must be added for list styles. Add one of the following variants to the `modifier` attribute of the `cdr-list` tag to change the visual presentation:
 

--- a/docs/components/modal/README.md
+++ b/docs/components/modal/README.md
@@ -272,26 +272,26 @@ This component complies with WCAG guidelines by:
   - Pressing the escape key (ESC)
 - Modal opens one at a time and are never displayed in groups
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Events
+### Events
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.events" :slots-getting-started-link="false" />
 
-## Usage
+### Usage
 
-### Modal Title
+#### Modal Title
 
 If the `title` slot is left empty, the `label` prop will be rendered as the title. The title can be hidden altogether by setting `showTitle` to `false`.
 
@@ -307,7 +307,7 @@ When using the `label` slot, add CdrText to use the appropriate header styles.
 </template>
 ```
 
-### `modal` Override Slot
+#### `modal` Override Slot
 
 The `modal` override slot provides teams a way to work from essentially a blank slate when creating their modal content. This is useful for situations where more art-direction or custom functionality is required. It is important to note that creating a clear way to close the modal is still required to meet user-experience and accessibility standards (i.e. relying only on the esc key is not enough).
   
@@ -328,15 +328,15 @@ The `modal` override slot provides teams a way to work from essentially a blank 
   </cdr-modal>
 ```
   
-### Size
+#### Size
 
 The modal has a default width of `640px` which converts to a fullscreen view at `xs` screen sizes.
 
-### Scroll Behavior
+#### Scroll Behavior
 
 The modal content area will scroll vertically if there's enough content. The modal title does not scroll; it stays affixed to the top of the modal.
 
-### Keep Alive
+#### Keep Alive
 
 Do not use `v-if` with CdrModal unless the component is wrapped with `keep-alive`. CdrModal handles showing and hiding itself when toggling, so `v-if` should be unneeded in most cases.
 

--- a/docs/components/pagination/README.md
+++ b/docs/components/pagination/README.md
@@ -143,8 +143,9 @@
 
 <cdr-doc-table-of-contents-shell>
 
-# Overview
-## Pagination @ sm, md, lg
+## Overview
+
+### Pagination @ sm, md, lg
 
 At the sm, md, and lg breakpoints, pagination displays as a list of number text links. Prev and Next links are also added when applicable.
 
@@ -159,7 +160,7 @@ At the sm, md, and lg breakpoints, pagination displays as a list of number text 
 ```
 </cdr-doc-example-code-pair>
 
-## Intra-Page Navigation
+### Intra-Page Navigation
 
 By default, CdrPagination assumes that you are navigating through pages on a site and will update the URL on change. For content that requires pagination but is part of a larger page the `linkTag` and `forLabel` properties can be used to render a button based pagination. Set `linkTag` to be `"button"` and set the `forLabel` to describe what element is being paginated, for example `"Pagination for user reviews"`
 
@@ -176,7 +177,7 @@ By default, CdrPagination assumes that you are navigating through pages on a sit
 ```
 </cdr-doc-example-code-pair>
 
-## Overriding Default Navigation
+### Overriding Default Navigation
 
 By default pagination uses anchor elements which navigate the users web browser when clicked. This behavior can be overriden by adding a handler to the `navigate` event which emits `(currentPage, currentUrl, event)` and calling `event.preventDefault()` in the handler function. The `currentPage` and `currentUrl` can then be used to implement router based navigation or programmatically navigate the page. This can also be used in conjunction with the `link-tag` property to render a button based pagination.
 
@@ -196,13 +197,13 @@ By default pagination uses anchor elements which navigate the users web browser 
 
 </cdr-doc-example-code-pair>
 
-## Pagination @ xs
+### Pagination @ xs
 
 At the xs breakpoint, pagination adapts to a Select component using the native UI dropdown menu.
 
 <img :src="$withBase('/pagination/pagination_breakpoint_xs_2x.png')" alt="Responsive pagination component using Select element" />
 
-## Accessibility
+### Accessibility
 
 This component complies with accessibility guidelines by doing the following:
 
@@ -239,9 +240,9 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## SEO
+### SEO
 
 For best SEO support, use of pagination requires additional markup and logic in the `<head>` of the page.
 
@@ -249,17 +250,17 @@ See REI's SEO Confluence page on [pagination](https://confluence.rei.com/display
 
 Note that REI has chosen HTML `<link>` elements instead of HTTP headers. Make sure to use fully qualified absolute URLs in the `<link>` elements instead of relative URLs.
 
-## Use When
+### Use When
 - Providing navigation to break apart large quantities of content
 - Breaking up search result pages into manageable sections
 
-## Don't Use When
+### Don't Use When
 
 - Using lazy load or infinite scroll within an experience
 - Switching between slides or content in a carousel
 - Displaying editorial content. Instead, show entire article on one page
 
-## Behavior
+### Behavior
 
 - Page number links are truncated as follows: [first] ... [current-1] [current] [current+1] ... [last]
 - If there are 7 pages or fewer, all page number links will be shown
@@ -271,7 +272,7 @@ Within pagination, link styles are adapted
 - Prev and Next links use the small size for the caret-left and caret-right icons
 
 
-### Do / Don't
+#### Do / Don't
 
 By default, pagination is center aligned under category or search results content.
 
@@ -295,15 +296,15 @@ Pagination adapts to a Select component with a native UI dropdown menu on XS bre
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 

--- a/docs/components/popover/README.md
+++ b/docs/components/popover/README.md
@@ -216,20 +216,20 @@ Example:
 
 <do-dont :examples="$page.frontmatter.essential" />
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Events
+### Events
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.events" :slots-getting-started-link="false" />
 

--- a/docs/components/pull-quote/README.md
+++ b/docs/components/pull-quote/README.md
@@ -136,8 +136,9 @@
 
 <cdr-doc-table-of-contents-shell>
 
-# Overview
-## Default (Medium)
+## Overview
+
+### Default (Medium)
 
 Default pull quote can be used with the following HTML tags: `<p>`, `<div>`, `<aside>`. For XS breakpoint, a border is added below the pull quote and the font size is smaller.
 
@@ -155,7 +156,7 @@ Default pull quote can be used with the following HTML tags: `<p>`, `<div>`, `<a
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 To ensure that usage of this component complies with accessibility guidelines:
 
@@ -172,21 +173,21 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Attracting the user’s attention to article text
 - Breaking up a large body of text
 - Providing the reader with visual markers
 - Maintaining a sense of sequence and place
 
-## Don't Use When
+### Don't Use When
 
 - Displaying a citation reference. Instead, use [Block Quote](../block-quote/)
 - Displaying for a decorative treatment only
 
-## The Basics
+### The Basics
 
 Use a pull quote for emphasizing content that has a close and significant relationship with the surrounding text and will help users to visually scan the page.
 
@@ -198,18 +199,18 @@ Use a pull quote for emphasizing content that has a close and significant relati
 
 <do-dont :examples="$page.frontmatter.position" />
 
-## Responsiveness
+### Responsiveness
 
 When a pull quote is displayed at XS breakpoint, the left border will appear below the pull quote and will use a smaller font size.
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 

--- a/docs/components/radio/README.md
+++ b/docs/components/radio/README.md
@@ -148,8 +148,10 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
-## Default (Medium)
+
+## Overview
+
+### Default (Medium)
 Default and standard spacing for radio buttons.
 
 <cdr-doc-example-code-pair :repository-href="$page.frontmatter.component_location" :sandbox-data="$page.frontmatter.sandboxData" :codeMaxHeight="false" :model="{ex: ''}">
@@ -193,7 +195,7 @@ Default and standard spacing for radio buttons.
 
 </cdr-doc-example-code-pair>
 
-## Size
+### Size
 
 Different sizing for radio buttons.
 
@@ -241,7 +243,7 @@ Different sizing for radio buttons.
 
 </cdr-doc-example-code-pair>
 
-## Custom
+### Custom
 
 Custom styles for radio buttons.
 
@@ -296,7 +298,7 @@ Custom styles for radio buttons.
 </cdr-doc-example-code-pair>
 
 
-## Validation
+### Validation
 
 Render a radio group with validation and error state
 
@@ -330,7 +332,7 @@ Render a radio group with validation and error state
 ```
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:
@@ -358,21 +360,21 @@ For more information, review techniques and failures for:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Selecting only 1 choice from a list is allowed
 - Viewing all available options is needed
 - Comparing between list of selections is desired
 
 
-## Don't Use When
+### Don't Use When
 
 - Selecting from a list when multiple choices are allowed. Instead, use [Checkboxes](../checkboxes/)
 - Providing a single selectable option. Instead, use [Checkboxes](../checkboxes/) as a stand-alone checkbox
 
-## Content
+### Content
 When using radio buttons in a list:
 - Use a logical order, whether it’s alphabetical, numerical, or time-based
 - Labels should have approximately equal length
@@ -388,7 +390,7 @@ Radio button labels should:
 - Be written as sentence fragments
 - No terminal punctuation
 
-### Do/Don't
+#### Do/Don't
 
 <do-dont :examples="$page.frontmatter.case" />
 
@@ -396,40 +398,40 @@ Radio button labels should:
 
 <do-dont :examples="$page.frontmatter.fragment" />
 
-## Resources
+### Resources
 
 - WebAIM: [Semantic Structure: Using Lists Correctly](https://webaim.org/techniques/semanticstructure/)
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML radio element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio) accepts.
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props"/>
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots"/>
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events"/>
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrLabelWrapper"/>
 
-## Usage
+### Usage
 
 The **CdrRadio** component requires `v-model` to track the value of selected radios.
 
-### Modifiers
+#### Modifiers
 
 Following variants are available to the `cdr-radio` modifier attribute:
 | Value | Description            |

--- a/docs/components/rating/README.md
+++ b/docs/components/rating/README.md
@@ -116,11 +116,11 @@
 
 <cdr-doc-table-of-contents-shell>
 
-# Overview
+## Overview
 
 <cdr-banner type="info" aria-live="polite"><template #icon-left><icon-information-fill inherit-color /></template><strong>REI.com is currently using Bazaarvoice for ratings.</strong><template #message-body>Styles documented here may not reflect the current styles provided by the tool. Reach out in <cdr-link href="https://rei.slack.com/messages/CA58YCGN4" target="\_blank">#cedar-user-support</cdr-link> for further guidance or questions.</template></cdr-banner>
 
-## Default (Medium)
+### Default (Medium)
 
 Shows review rating with up to 5 stars highlighted. If rating is zero, star icons are displayed using the grey outline star icon.
 
@@ -136,7 +136,7 @@ Shows review rating with up to 5 stars highlighted. If rating is zero, star icon
 
 </cdr-doc-example-code-pair>
 
-## Linked
+### Linked
 
 Creates a link to the corresponding review content if on the same page.
 
@@ -155,7 +155,7 @@ Creates a link to the corresponding review content if on the same page.
 
 </cdr-doc-example-code-pair>
 
-## Compact (Small)
+### Compact (Small)
 
 Removes the word "Reviews" from the label for limited space layout.
 
@@ -171,7 +171,7 @@ Removes the word "Reviews" from the label for limited space layout.
 
 </cdr-doc-example-code-pair>
 
-## Sizing
+### Sizing
 
 Change size for the star icon and text. Default size is medium.
 
@@ -196,7 +196,7 @@ Change size for the star icon and text. Default size is medium.
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:
@@ -216,28 +216,28 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Providing a tool for comparing others’ opinions
 
-## Don't Use When
+### Don't Use When
 
 - Displaying a range of data
 
-## Content
+### Content
 
 - Always display the number of reviews next to the star rating
 - Use accompanying text label ‘Reviews’ when space allows
 
 
-## Behavior
+### Behavior
 
 - Rating appears with grey outlined stars when no reviews are available
 - Link to the corresponding review content if on the same page
 
-### Do / Don’t
+#### Do / Don’t
 
 <br/>
 
@@ -253,20 +253,20 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Usage
+### Usage
 
 By default the **CdrRating** component renders the icons in medium size (24px) with the total number of reviews.
 
-### Rating Values
+#### Rating Values
 - The count for reviews will always be visible
 - Ratings are rounded to the nearest .25 because icons are represented in 25% increments
 - Screen reader text is provided which reads, “Rated [ rounded ] out of 5 with [ count ] reviews”

--- a/docs/components/selects/README.md
+++ b/docs/components/selects/README.md
@@ -189,9 +189,9 @@
 
 
 <cdr-doc-table-of-contents-shell tab-name="Overview">
-# Overview
+## Overview
 
-## Default (Medium)
+### Default (Medium)
 
 Basic select control with label.
 
@@ -220,7 +220,7 @@ Basic select control with label.
 </cdr-doc-example-code-pair>
 
 
-## Bare
+### Bare
 
 Basic select control with no label.
 
@@ -250,7 +250,7 @@ Basic select control with no label.
 </cdr-doc-example-code-pair>
 
 
-## Select with Link Text
+### Select with Link Text
 
 Select control with link text on right.
 
@@ -296,7 +296,7 @@ Select control with link text on right.
 </cdr-doc-example-code-pair>
 
 
-## Select with Info Action
+### Select with Info Action
 
 Select control with icon outside select field on right.
 
@@ -321,7 +321,7 @@ Select control with icon outside select field on right.
 </cdr-doc-example-code-pair>
 
 
-## Select with Helper Text
+### Select with Helper Text
 
 Input field with helper or hint text below the input field.
 
@@ -357,7 +357,7 @@ Input field with helper or hint text below the input field.
 </cdr-doc-example-code-pair>
 
 
-## Validation
+### Validation
 
 Error prop and slot can be used to render the select in an error state
 
@@ -378,7 +378,7 @@ Error prop and slot can be used to render the select in an error state
 
 </cdr-doc-example-code-pair>
 
-## Multiple Select
+### Multiple Select
 
 CdrSelect can be rendered as a multi-select by passing the native HTML select `multiple` attribute. The `multipleSize` prop can be used to control the height of the multi-select.
 
@@ -409,7 +409,7 @@ With multipleSize:
 
 </cdr-doc-example-code-pair>
 
-## Nested Options
+### Nested Options
 
 CdrSelect can be rendered with nested options using the `optgroup` tag.
 
@@ -436,7 +436,7 @@ CdrSelect can be rendered with nested options using the `optgroup` tag.
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 To ensure that the usage of Select component complies with the accessibility guidelines:
 + Always provide a label for each select control
@@ -455,15 +455,15 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 + Choosing an option from a predefined set of values
 + Recommending a default option for most users
 
 
-## Don't Use When
+### Don't Use When
 
 + Viewing or comparing all options is needed. Instead, use [Radio Buttons](../radio/)
 + Displaying a limited number of options. Instead, use [Radio Buttons](../radio/)
@@ -474,7 +474,7 @@ This component has compliance with WCAG guidelines by:
 + Sending the user to other areas of the site. Instead, use [Links](../links/)
 
 
-## The Basics
+### The Basics
 
 Select and dropdown components tend to look similar, but have different functionality. While select is used for selecting from a list of options and submitting that data, dropdowns contain links and take users elsewhere. Also, the select appearance is owned by the browser, whereas dropdowns can be styled.
 
@@ -483,26 +483,26 @@ Select components should be:
 + **Findable:** It should be easy to find a select field among other elements
 + **Legible:** Select fields indicate their state such as enabled, focused, or disabled
 
-### Options
+#### Options
 + Define width using CSS styles
 + Height options are medium and large. These variations can be used for creating media queries for responsive layouts, or to call more or less attention to the component.
 
 
-## Content
+### Content
 
-### Labels
+#### Labels
 
 + Use concise and consistent labels that describe the meaning of the select field
 + Limit labels to 1–3 words and fewer than 20 characters, including spaces
 + Use sentence case only. Do not use all caps, title case, or lowercase
 + Don’t use colons after labels
 
-### Prompt Text
+#### Prompt Text
 
 + Limit prompt text to 1–3 words
 + Use descriptive prompt text for accessibility users who use screen readers to fill out forms
 
-### Menu or List Text
+#### Menu or List Text
 
 + Use sentence case
 + Simplify the list. If an option is rarely selected, consider removing it from the list
@@ -511,23 +511,23 @@ Select components should be:
   + Alpha: For example, state or city locations
   + Numeric: For example, distances or sizes
 
-### Helper Text
+#### Helper Text
 
 + Use helper text for hints or suggestions
 + Be succinct. Too much helper text can make a form look and feel difficult to use
 
-### Icon
+#### Icon
 
 - Use icons to trigger a [popover](../popover) or [tooltip](../tooltip) for hints or suggestions
 - Reference Cedar's [icon guidelines](../icon/#guidelines) for additional information
 
-### Link Text
+#### Link Text
 
 - Use a link in the `info` slot when moving or navigating to another page or to a different portion of the same page
 - Use if navigating user to long or complex information
 - Reference the [Links](../links/) component article for more information
 
-### Do / Don’t
+#### Do / Don’t
 
 <br/>
 
@@ -538,40 +538,40 @@ Select components should be:
 <do-dont :examples="$page.frontmatter.punctuation" />
 
 
-## Behavior
+### Behavior
 
 + Avoid changing options in a dropdown menu based on the input from a different select field
 + Use a prompt in the format of “Select a…” or “Select category…”
 
-### Required Fields
+#### Required Fields
 
 + An asterisk will appear next to the input label if the status is required and the input field will have `aria-required` set
 
-### Validation
+#### Validation
 
 + Validate the user’s data before form submission. The `error` property and slot can be used to render a message on error.
 
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 This component will bind any attribute that a [native HTML select element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select) accepts.
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props"/>
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" :slots-getting-started-link="false" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrSelect">Note that the <a href="../component-variables/#CdrLabelStandalone">cdr-label-standalone mixins</a> should be used for assembling the label element. </cdr-doc-comp-vars>
 

--- a/docs/components/table/README.md
+++ b/docs/components/table/README.md
@@ -83,9 +83,9 @@
 
 <br>
 
-# Overview
+## Overview
 
-## Default
+### Default
 
 The default table is medium sized, bordered, full width, and has responsive overflow scrolling.
 
@@ -121,7 +121,7 @@ The default table is medium sized, bordered, full width, and has responsive over
 
 </cdr-doc-example-code-pair>
 
-## Striped
+### Striped
 
 Alternating light/dark backgrounds.
 
@@ -158,7 +158,7 @@ Alternating light/dark backgrounds.
 </cdr-doc-example-code-pair>
 
 
-## Border
+### Border
 
 Adds border between rows
 
@@ -194,7 +194,7 @@ Adds border between rows
 
 </cdr-doc-example-code-pair>
 
-## Advanced with custom styles
+### Advanced with custom styles
 
 This is an advanced example with multiple headers and a custom class to change the background color for headers inside `<tbody>`
 
@@ -269,7 +269,7 @@ This is an advanced example with multiple headers and a custom class to change t
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 Many WCAG requirements are contextual to their implementation.
 To ensure that usage of this component complies with accessibility guidelines you are responsible for the following:
@@ -297,40 +297,40 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Presenting multiple metrics and categories together
 - Displaying tabular data for users to compare
 
-## Don't Use When
+### Don't Use When
 
 - Positioning contents on page. Instead, use [Grid](../grid/)
 - Laying out a page design. Instead, use [Grid](../grid/)
 
-## The Basics
+### The Basics
 
 - Use on either light or dark backgrounds.
 - Content within tables can include text, photos, graphics, or other components (i.e. links, buttons, icons)
 
-## Anatomy
+### Anatomy
 
 - `cdr-table` like `cdr-grid` is a wrapper component without predetermined layout requirements. This allows you the flexibility to construct the structure you need to accurately display the data you have. There are cases where you might need to change background colors or add additional borders (see the [advanced example](#advanced-with-custom-styles)). When this is done, tokens for the table colors (background, border, etc.) should be used so your customizations can persist through future cedar updates.
 - Our table component provides the visual class only and does not account for markup requirements to create an accessible table. Be sure to review the examples and the accessibility requirements for this component.
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Component Variables
+### Component Variables
 
 <cdr-doc-comp-vars name="CdrTable"/>
 

--- a/docs/components/tabs/README.md
+++ b/docs/components/tabs/README.md
@@ -147,11 +147,11 @@
 
 
 <cdr-doc-table-of-contents-shell>
-# Overview
+## Overview
 
 <cdr-banner type="warning" aria-live="polite"><template #icon-left><icon-warning-fill inherit-color /></template>Due to an issue with how Codesandbox handles link clicks, the CdrTabs examples do not work properly in the Codesandbox environment.</cdr-banner>
 
-## Default (Medium)
+### Default (Medium)
 Tabs align left and bottom border expands to full width of container.
 
 <cdr-doc-example-code-pair :repository-href="$page.frontmatter.component_location" :sandbox-data="$page.frontmatter.sandboxData" :backgroundToggle="false" :codeMaxHeight="false" >
@@ -169,7 +169,7 @@ Tabs align left and bottom border expands to full width of container.
 
 </cdr-doc-example-code-pair>
 
-## Compact (Small)
+### Compact (Small)
 
 Reduced spacing around the tabs to create a denser visual design.
 
@@ -186,7 +186,7 @@ Reduced spacing around the tabs to create a denser visual design.
 
 </cdr-doc-example-code-pair>
 
-## Full Width
+### Full Width
 
 Tabs space evenly across the container.
 
@@ -203,7 +203,7 @@ Tabs space evenly across the container.
 
 </cdr-doc-example-code-pair>
 
-## No Border
+### No Border
 
 Bottom border of tab header list is removed.
 
@@ -220,7 +220,7 @@ Bottom border of tab header list is removed.
 
 </cdr-doc-example-code-pair>
 
-## Centered
+### Centered
 
 Centered tab header content.
 
@@ -237,7 +237,7 @@ Centered tab header content.
 
 </cdr-doc-example-code-pair>
 
-## Active Tab
+### Active Tab
 
 Tabs using the `active-tab` property to make the third element active on page load.
 
@@ -254,7 +254,7 @@ Tabs using the `active-tab` property to make the third element active on page lo
 
 </cdr-doc-example-code-pair>
 
-## Auto
+### Auto
 
 Tabs using `height="auto"` to render with variable height based on content size.
 
@@ -276,7 +276,7 @@ Tabs using `height="auto"` to render with variable height based on content size.
 
 </cdr-doc-example-code-pair>
 
-## Accessibility
+### Accessibility
 
 Tabs component maintains these keyboard interactions:
 
@@ -295,29 +295,29 @@ This component has compliance with WCAG guidelines by:
 
 <hr>
 
-# Guidelines
+## Guidelines
 
-## Use When
+### Use When
 
 - Organizing related content in a single container
 - Flipping between multiple panes or sections
 - Grouping content to display horizontally
 - Content can be broken into discrete parts
 
-## Don't Use When
+### Don't Use When
 
 - Grouping content to display vertically. Instead, use [Accordion](../accordion/)
 - Creating primary navigation that links to other pages
 - Comparing related content. Instead, use [Table](../table/)
 
-## The Basics
+### The Basics
 
 - Keep tabs in the same order, even when some tabs are disabled
 - Keep to no more than 6 tabs
 - Never display fewer than 2 tabs
 - Avoid changing the order of the tabs often. If your content changes frequently and needs to be selectively displayed, consider adopting a Filter pattern as in Product Display (https://www.rei.com/c/mens-climbing-shoes)
 
-## Content
+### Content
 
 - Order the tabs by priority or importance from left to right
 - Keep tab labels short and meaningful. Between 1-2 words is best and written in plain language
@@ -326,7 +326,7 @@ This component has compliance with WCAG guidelines by:
 - Use title caps for tab labels
 - Tab headers can be animated, but tab content should not be
 
-## Behavior
+### Behavior
 
 - The first tab section is selected by default
 - Only one tab can be selected at a time
@@ -335,7 +335,7 @@ This component has compliance with WCAG guidelines by:
 - Tabs become scrollable when the length of the labels exceed the width of the container
 - Inactive tab panels are rendered for SEO purposes
 
-### Do/Don't
+#### Do/Don't
 
 <do-dont :examples="$page.frontmatter.select" />
 
@@ -345,7 +345,7 @@ This component has compliance with WCAG guidelines by:
 
 <do-dont :examples="$page.frontmatter.label" />
 
-## Responsiveness
+### Responsiveness
 
 - Tabs can change styles based on breakpoint
   - Example: _Default_ at MD/LG, _Compact_ and _Full Width_ at XS/SM
@@ -362,28 +362,28 @@ Linking to a specific tab or accordion has SEO costs. If you still wish to imple
 
 <hr>
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
 Tabs are built from two components: **CdrTabs** and **CdrTabPanel**. These are meant to be used together.
 
-## Props
+### Props
 
-### CdrTabs
+#### CdrTabs
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props"/>
 
-### CdrTabPanel
+#### CdrTabPanel
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[1].api.props"/>
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Usage
+### Usage
 
 The `cdr-tab-panel name` property sets the tab display value and is used for reference.
 
@@ -393,7 +393,7 @@ The `cdr-tab-panel name` property sets the tab display value and is used for ref
  </cdr-tabs>
 ```
 
-### Modifiers
+#### Modifiers
 
 Following variants are available to the `cdr-tabs` modifier attribute:
 | Value        | Description            |

--- a/docs/components/text/README.md
+++ b/docs/components/text/README.md
@@ -899,18 +899,18 @@ Cedar uses design tokens to store typographic attributes that represent the fund
 
 For more information about design tokens and a complete list of tokens available in Cedar, visit the [Design Tokens](../../tokens/overview/) overview.
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Usage
+### Usage
 
 The **CdrText** component allows for styling any HTML element with available text styles. Visual style and semantic meaning are managed independently by providing:
 
@@ -986,7 +986,7 @@ Note that heading styles do not always need to be paired with heading tags. Head
 </cdr-doc-code-snippet>
 
 
-## Text Options
+### Text Options
 
 <text-doc-overview />
 

--- a/docs/components/toast/README.md
+++ b/docs/components/toast/README.md
@@ -257,34 +257,34 @@ Use to provide generic messaging that does not fit the other types
 - Toasts are delivered from the top-right of a page 
 - The most recent toast is always displayed on top of a stack 
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Events
+### Events
 
 <cdr-doc-api type="event" :api-data="$page.frontmatter.versions[0].components[0].api.events" />
 
-## Usage
+### Usage
 
-### Positioning
+#### Positioning
 
 CdrToast component(s) should be contained within a `position: absolute` container in the top-right corner of your page. On smaller screens, they should appear at the top of the page and span the whole width of the viewport.
 
-### Elevation
+#### Elevation
 
 The CdrToast container should be be given an appropriate `z-index` value so that the toast components within will "float" on top of the other page elements.
 
-### Multiples
+#### Multiples
 
 If multiple CdrToast components are present, they should appear stacked with the newest at the bottom. Note: When a toast is closed, any toast components below it will take the place of the one above.
 

--- a/docs/components/tooltip/README.md
+++ b/docs/components/tooltip/README.md
@@ -223,20 +223,20 @@ Example:
 <do-dont :examples="$page.frontmatter.consistency" />
 <do-dont :examples="$page.frontmatter.redundancy" />
 
-# API
+## API
 
 <cdr-icon class="cdr-doc-code-snippet__action-icon" use="#brand-github"/> View it on Github: 
 <cdr-link :href="$page.frontmatter.component_location">{{$page.frontmatter.component_location}}</cdr-link>
 
-## Props
+### Props
 
 <cdr-doc-api type="prop" :api-data="$page.frontmatter.versions[0].components[0].api.props" />
 
-## Slots
+### Slots
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.slots" />
 
-## Events
+### Events
 
 <cdr-doc-api type="slot" :api-data="$page.frontmatter.versions[0].components[0].api.events" :slots-getting-started-link="false" />
 


### PR DESCRIPTION
Many H tags on component pages are incorrect, leading to a hard-to-understand hierarchy. There is one H1 on the page— component name on the header. However, Overview, Guidelines, and API were all labeled with an H1, even though they should be H2s. I've adjusted the H tags accordingly to be consistent.