### PR TITLE
Add noindex to head for all pages

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,6 +9,7 @@ module.exports = {
     ["link", { rel: "stylesheet", href: "/cedar.css" }],
     ["link", { rel: "stylesheet", href: "/back-to-top-btn.css" }],
     ["meta", { property: "og:image", content: "https://rei.github.io/rei-cedar-docs/og.png" }],
+    ["meta", { name: "robots", content: "noindex"}],
   ],
   ga: '',
   plugins: [


### PR DESCRIPTION
Attempting to delist the legacy site from search to allow the new one to takeover. Verified this strategy with the technical SEO team